### PR TITLE
chore: update devcontainer comments

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,10 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/go/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/devcontainers/images/blob/main/src/go/.devcontainer/Dockerfile
 
-# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
+# [Choice] Go version: 1, 1.23, 1.24, 1-bookworm, 1.23-bookworm, 1.14-bookworm, 1-bullseye, 1.23-bullseye, 1.24-bullseye
 ARG VARIANT=1-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/go:${VARIANT}
 
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 24, 22, 20
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,12 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/go
+// For format details, see https://containers.dev/implementors/json_reference.
+// For config options, see the README at: https://github.com/devcontainers/images/tree/main/src/go
 {
   "name": "oh-my-posh",
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      // Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
-      // Append -bullseye or -buster to pin to an OS version.
-      // Use -bullseye variants on local arm64/Apple Silicon.
+      // Update the VARIANT arg to pick a version of Go: 1, 1.23, 1.24
+      // Append -bookworm or -bullseye to pin to an OS version.
       "VARIANT": "1-1.24-bullseye",
 
       // Override me with your own timezone:


### PR DESCRIPTION
## Summary by Sourcery

Update devcontainer comments to reference the new devcontainers/images repository and refresh the listed Go and Node.js version options

Chores:
- Update Dockerfile comments to point to the new devcontainers/images source
- Refresh the available Go version selection list
- Refresh the available Node.js version selection list