### PR TITLE
docs: add terraform icon to sample configuration

### DIFF
--- a/website/docs/segments/cli/terraform.mdx
+++ b/website/docs/segments/cli/terraform.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#000000",
     background: "#ebcc34",
-    template: "{{.WorkspaceName}}",
+    template: " \ue69a {{.WorkspaceName}}",
   }}
 />
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add a Terraform icon glyph to the documented sample configuration template for the CLI segment.