### PR TITLE
fix: add missing triple colon to ArgoCD

### DIFF
--- a/website/docs/segments/cli/argocd.mdx
+++ b/website/docs/segments/cli/argocd.mdx
@@ -31,6 +31,8 @@ import Config from "@site/src/components/Config.js";
 {{ .Name }}
 ```
 
+:::
+
 ### Properties
 
 | Name      | Type     | Description                       |


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Restore a missing closing triple-colon in the ArgoCD CLI documentation to render the content block correctly.