### PR TITLE
fix(docs): add missing default folders to lua

### DIFF
--- a/website/docs/segments/languages/lua.mdx
+++ b/website/docs/segments/languages/lua.mdx
@@ -35,7 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                     | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `tooling`              | `[]string` |   `lua, luajit`     | the tooling to use for fetching the version                                                                                                                                                                                          |
 | `extensions`           | `[]string` | `*.lua, *.rockspec` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
-| `folders`              | `[]string` |                     | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `folders`              | `[]string` |        `lua`        | allows to override the list of folder names to validate                                                                                                                                                                              |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Specify `lua` as the default folder name for Lua language validation configuration.