### PR TITLE
fix(docs): add missing default folders to bazel

### DIFF
--- a/website/docs/segments/cli/bazel.mdx
+++ b/website/docs/segments/cli/bazel.mdx
@@ -34,7 +34,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                                                             | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info documentation                                                                                                                  |
 | `icon`                 |  `string`  |                          `\ue63a`                           | the icon for the segment                                                                                                                                                                                                             |
 | `extensions`           | `[]string` | `*.bazel, *.bzl, BUILD, WORKSPACE, .bazelrc, .bazelversion` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
-| `folders`              | `[]string` |                                                             |                                                                                                                                                                                                                                      |
+| `folders`              | `[]string` |          `bazel-bin`, `bazel-out`, `bazel-testlogs`         | allows to override the list of folder names to validate                                                                                                                                                                              |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add the default Bazel folders (bazel-bin, bazel-out, bazel-testlogs) to the CLI segment configuration documentation.