### PR TITLE
feat(segment): update pnpm icon

### DIFF
--- a/src/segments/node.go
+++ b/src/segments/node.go
@@ -64,7 +64,7 @@ func (n *Node) loadContext() {
 			fileName:     "pnpm-lock.yaml",
 			name:         "pnpm",
 			iconProperty: PnpmIcon,
-			defaultIcon:  "\U000F02C1",
+			defaultIcon:  "\ue865",
 		},
 		{
 			fileName:     "yarn.lock",

--- a/src/segments/pnpm.go
+++ b/src/segments/pnpm.go
@@ -20,5 +20,5 @@ func (n *Pnpm) Enabled() bool {
 }
 
 func (n *Pnpm) Template() string {
-	return " \U000F02C1 {{.Full}} "
+	return " \ue865 {{.Full}} "
 }

--- a/src/segments/pnpm_test.go
+++ b/src/segments/pnpm_test.go
@@ -13,7 +13,7 @@ func TestPnpm(t *testing.T) {
 		ExpectedString string
 		Version        string
 	}{
-		{Case: "1.0.0", ExpectedString: "\U000F02C1 1.0.0", Version: "1.0.0"},
+		{Case: "1.0.0", ExpectedString: "\ue865 1.0.0", Version: "1.0.0"},
 	}
 	for _, tc := range cases {
 		params := &mockedLanguageParams{

--- a/website/docs/segments/cli/pnpm.mdx
+++ b/website/docs/segments/cli/pnpm.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#000000",
     background: "#F9AD00",
-    template: " \uDB80\uDEC1 {{ .Full }} ",
+    template: " \ue865 {{ .Full }} ",
   }}
 />
 
@@ -41,7 +41,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-\uDB80\uDEC1 {{.Full}}
+\ue865 {{.Full}}
 ```
 
 :::


### PR DESCRIPTION
## Summary by Sourcery

Update the pnpm segment to use a new icon consistently across code, tests, and documentation.

Enhancements:
- Change the default pnpm icon used by the node and pnpm segments to a new glyph.

Documentation:
- Update pnpm CLI segment documentation examples to reflect the new icon.

Tests:
- Adjust pnpm segment tests to assert the new icon output.