### PR TITLE
docs(blog): add a docusaurus truncation marker

### DIFF
--- a/website/blog/2025-12-28-oh-my-posh-claude-code-integration.md
+++ b/website/blog/2025-12-28-oh-my-posh-claude-code-integration.md
@@ -26,6 +26,7 @@ development workflow and AI-powered coding assistance.
 
 ![Claude Code](/img/claude.png)
 
+<!--truncate-->
 ## What is Claude Code's statusline?
 
 Claude Code's `statusline` feature allows you to create custom status displays that appear at the bottom of


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the Claude Code integration blog post to include a truncation marker for better excerpt handling on listing pages.