### PR TITLE
fix(docs): use JSX instead of html

### DIFF
--- a/website/blog/2022-03-20-whats-new-1.mdx
+++ b/website/blog/2022-03-20-whats-new-1.mdx
@@ -17,9 +17,17 @@ What a week it’s been! Oh My Posh turned 6 years old and we dropped a ton of s
 ## Swag
 
 After seeing Scott Hanselman wear his oh my zsh shirt while we got to talk about
-Oh My Posh on [Windows Wednesdays] [windows-wednesdays], I got the sudden urge to expand his wardrobe.
+Oh My Posh on [Windows Wednesdays][windows-wednesdays], I got the sudden urge to expand his wardrobe.
 
-<iframe class="youtube" src="https://www.youtube.com/embed/uO_F5W2LbSk" frameborder="0" allowfullscreen></iframe>
+<iframe
+  className="youtube"
+  src="https://www.youtube.com/embed/uO_F5W2LbSk"
+  title="Windows Wednesdays: Oh My Posh"
+  frameBorder="0"
+  referrerPolicy="strict-origin-when-cross-origin"
+  loading="lazy"
+  allowFullScreen
+/>
 
 And so, we did. Got in touch with [Marc Duiker][marc] and we got to work. The result? A ton of new goodies.
 Consider this to be **the first artist series** for Oh My Posh, a way to also highlight some talented


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adjust blog link reference formatting and iframe attributes to conform to JSX/MDX conventions in the documentation site.