### PR TITLE
fix(music): update music segments information

### DIFF
--- a/src/segments/spotify.go
+++ b/src/segments/spotify.go
@@ -38,10 +38,10 @@ func (s *Spotify) resolveIcon() {
 	switch s.Status {
 	case stopped:
 		// in this case, no artist or track info
-		s.Icon = s.options.String(StoppedIcon, "\uF04D ")
+		s.Icon = s.options.String(StoppedIcon, "\uf04d ")
 	case paused:
-		s.Icon = s.options.String(PausedIcon, "\uF8E3 ")
+		s.Icon = s.options.String(PausedIcon, "\uf04c ")
 	case playing:
-		s.Icon = s.options.String(PlayingIcon, "\uE602 ")
+		s.Icon = s.options.String(PlayingIcon, "\ue602 ")
 	}
 }

--- a/src/segments/spotify_darwin_test.go
+++ b/src/segments/spotify_darwin_test.go
@@ -22,7 +22,7 @@ func TestSpotifyDarwinEnabledAndSpotifyPlaying(t *testing.T) {
 		{BatchedCase: "false|||", Expected: "", Enabled: false},
 		{BatchedCase: "false||", Expected: "", Error: errors.New("oops"), Enabled: false},
 		{BatchedCase: "true|playing|Candlemass|Spellbreaker", Expected: "\ue602 Candlemass - Spellbreaker", Enabled: true},
-		{BatchedCase: "true|paused|Candlemass|Spellbreaker", Expected: "\uF8E3 Candlemass - Spellbreaker", Enabled: true},
+		{BatchedCase: "true|paused|Candlemass|Spellbreaker", Expected: "\uf04c Candlemass - Spellbreaker", Enabled: true},
 	}
 	batchedCommand := `
 	if application "Spotify" is running then

--- a/src/segments/spotify_linux_test.go
+++ b/src/segments/spotify_linux_test.go
@@ -24,8 +24,8 @@ func TestSpotifyLinux(t *testing.T) {
 	}{
 		{Case: "no data", ExpectedEnabled: false},
 		{Case: "error", ExpectedEnabled: false, Status: "Error.ServiceUnknown"},
-		{Case: "paused", ExpectedEnabled: true, Expected: "\uF8E3 Candlemass - Spellbreaker", Status: "paused", Artist: "Candlemass", Track: "Spellbreaker"},
-		{Case: "playing", ExpectedEnabled: true, Expected: "\uE602 Candlemass - Spellbreaker", Status: "playing", Artist: "Candlemass", Track: "Spellbreaker"},
+		{Case: "paused", ExpectedEnabled: true, Expected: "\uf04c Candlemass - Spellbreaker", Status: "paused", Artist: "Candlemass", Track: "Spellbreaker"},
+		{Case: "playing", ExpectedEnabled: true, Expected: "\ue602 Candlemass - Spellbreaker", Status: "playing", Artist: "Candlemass", Track: "Spellbreaker"},
 	}
 	for _, tc := range cases {
 		env := new(mock.Environment)

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -2278,15 +2278,15 @@
                 "properties": {
                   "playing_icon": {
                     "type": "string",
-                    "title": "User Info Separator",
+                    "title": "Playing Icon",
                     "description": "Text/icon to show when playing",
-                    "default": "\ue602"
+                    "default": "\uE602 "
                   },
                   "stopped_icon": {
                     "type": "string",
-                    "title": "SSH Icon",
+                    "title": "Stopped Icon",
                     "description": "Text/icon to show when stopped",
-                    "default": "\uf04d"
+                    "default": "\uF04D "
                   },
                   "api_key": {
                     "type": "string",
@@ -3708,19 +3708,19 @@
                     "type": "string",
                     "title": "Playing Icon",
                     "description": "Text/icon to show when playing",
-                    "default": "\ue602"
+                    "default": "\ue602 "
                   },
                   "paused_icon": {
                     "type": "string",
                     "title": "Paused Icon",
                     "description": "Text/icon to show when paused",
-                    "default": "\uf8e3"
+                    "default": "\uf04c "
                   },
                   "stopped_icon": {
                     "type": "string",
                     "title": "Stopped Icon",
                     "description": "Text/icon to show when stopped",
-                    "default": "\uf04d"
+                    "default": "\uf04d "
                   }
                 },
                 "additionalProperties": false
@@ -4388,13 +4388,13 @@
                     "type": "string",
                     "title": "Playing Icon",
                     "description": "Text/icon to show when playing",
-                    "default": "\ue602 "
+                    "default": "\uf04b "
                   },
                   "paused_icon": {
                     "type": "string",
                     "title": "Paused Icon",
                     "description": "Text/icon to show when paused",
-                    "default": "\uf8e3 "
+                    "default": "\uf04c "
                   },
                   "stopped_icon": {
                     "type": "string",
@@ -4402,11 +4402,11 @@
                     "description": "Text/icon to show when stopped",
                     "default": "\uf04d "
                   },
-                  "api_url": {
+                  "ad_icon": {
                     "type": "string",
-                    "title": "API URL",
-                    "description": "The YTMDA Remote Control API URL",
-                    "default": "http://127.0.0.1:9863"
+                    "title": "Advertisement Icon",
+                    "description": "Text/icon to show when an advertisement is playing",
+                    "default": "\ueebb "
                   },
                   "http_timeout": {
                     "$ref": "#/definitions/http_timeout"

--- a/website/docs/segments/music/lastfm.mdx
+++ b/website/docs/segments/music/lastfm.mdx
@@ -39,12 +39,13 @@ import Config from "@site/src/components/Config.js";
 
 ## Options
 
-| Name           |   Type   |  Default  | Description                    |
-| -------------- | :------: | :-------: | ------------------------------ |
-| `playing_icon` | `string` | `\uE602 ` | text/icon to show when playing |
-| `stopped_icon` | `string` | `\uF04D ` | text/icon to show when stopped |
-| `api_key`      | `string` |           | your LastFM [API key][api-key] |
-| `username`     | `string` |           | your LastFM username           |
+| Name           |   Type   |  Default  | Description                                    |
+| -------------- | :------: | :-------: | ---------------------------------------------- |
+| `playing_icon` | `string` | `\uE602 ` | text/icon to show when playing                 |
+| `stopped_icon` | `string` | `\uF04D ` | text/icon to show when stopped                 |
+| `api_key`      | `string` |    `.`    | your LastFM [API key][api-key]                 |
+| `username`     | `string` |    `.`    | your LastFM username                           |
+| `http_timeout` |  `int`   |   `20`    | in milliseconds - the timeout for http request |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/music/spotify.mdx
+++ b/website/docs/segments/music/spotify.mdx
@@ -29,10 +29,10 @@ import Config from "@site/src/components/Config.js";
     foreground: "#ffffff",
     background: "#1BD760",
     options: {
-      playing_icon: "\uE602 ",
-      paused_icon: "\uF8E3 ",
-      stopped_icon: "\uF04D ",
-    },
+      playing_icon: "\ue602 ",
+      paused_icon: "\uf04c ",
+      stopped_icon: "\uf04d "
+    }
   }}
 />
 
@@ -40,9 +40,9 @@ import Config from "@site/src/components/Config.js";
 
 | Name           |   Type   |  Default  | Description                    |
 | -------------- | :------: | :-------: | ------------------------------ |
-| `playing_icon` | `string` | `\uE602 ` | text/icon to show when playing |
-| `paused_icon`  | `string` | `\uF8E3 ` | text/icon to show when paused  |
-| `stopped_icon` | `string` | `\uF04D`  | text/icon to show when stopped |
+| `playing_icon` | `string` | `\ue602 ` | text/icon to show when playing |
+| `paused_icon`  | `string` | `\uf04c ` | text/icon to show when paused  |
+| `stopped_icon` | `string` | `\uf04d ` | text/icon to show when stopped |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/music/ytm.mdx
+++ b/website/docs/segments/music/ytm.mdx
@@ -6,7 +6,7 @@ sidebar_label: YouTube Music
 
 ## What
 
-Shows the currently playing song in the [YouTube Music Desktop App](https://github.com/ytmdesktop/ytmdesktop).
+Shows the currently playing song in the [YouTube Music Desktop App][ytmdesktop].
 
 ## Setup
 
@@ -45,22 +45,25 @@ import Config from "@site/src/components/Config.js";
       playing_icon: "\uf04b ",
       paused_icon: "\uf04c ",
       stopped_icon: "\uf04d ",
+      ad_icon: "\ueebb ",
+      http_timeout: 1000
     },
     cache: {
       duration: "5s",
-      strategy: "session",
-    },
+      strategy: "session"
+    }
   }}
 />
 
 ## Options
 
-| Name           |   Type   |  Default  | Description                                    |
-| -------------- | :------: | :-------: | ---------------------------------------------- |
-| `playing_icon` | `string` | `\uE602 ` | text/icon to show when playing                 |
-| `paused_icon`  | `string` | `\uF8E3 ` | text/icon to show when paused                  |
-| `stopped_icon` | `string` | `\uF04D ` | text/icon to show when stopped                 |
-| `http_timeout` |  `int`   |  `5000`   | in milliseconds - the timeout for http request |
+| Name           |   Type   |  Default  | Description                                        |
+| -------------- | :------: | :-------: | -------------------------------------------------- |
+| `playing_icon` | `string` | `\uf04b ` | text/icon to show when playing                     |
+| `paused_icon`  | `string` | `\uf04c ` | text/icon to show when paused                      |
+| `stopped_icon` | `string` | `\uf04d ` | text/icon to show when stopped                     |
+|   `ad_icon`    | `string` | `\ueebb ` | text/icon to show when an advertisement is playing |
+| `http_timeout` |  `int`   |  `5000`   | in milliseconds - the timeout for http request     |
 
 ## Template ([info][templates])
 
@@ -82,4 +85,4 @@ import Config from "@site/src/components/Config.js";
 | `.Icon`   | `string` | icon (based on `.Status`)                      |
 
 [templates]: /docs/configuration/templates
-[templates]: /docs/configuration/templates
+[ytmdesktop]: https://github.com/ytmdesktop/ytmdesktop


### PR DESCRIPTION
## Summary by Sourcery

Align music segment icons and documentation with actual runtime defaults and add support for an ad-specific icon and timeout option for YouTube Music and LastFM segments.

Enhancements:
- Standardize Spotify segment status icons with consistent glyph codes across implementation and documentation.

Documentation:
- Update YouTube Music, Spotify, and LastFM segment docs to reflect correct default icons and new configuration options, including ad icon and HTTP timeout settings.

Tests:
- Adjust Spotify integration tests to expect the updated icon glyphs for playing and paused states.