### PR TITLE
fix(docs): update broken links

### DIFF
--- a/website/blog/2022-03-20-whats-new-1.mdx
+++ b/website/blog/2022-03-20-whats-new-1.mdx
@@ -112,7 +112,7 @@ Obviously, nothing is perfect. But we aim to be! The following issues have been 
 
 That's it for this week, I'll try to keep this up 🤞🏻.
 
-_Keep that prompt posh everyone! _
+_Keep that prompt posh everyone!_
 
 [windows-wednesdays]: https://devblogs.microsoft.com/commandline/windows-wednesday/
 [marc]: https://twitter.com/marcduiker

--- a/website/blog/2022-05-19-whats-new-3.md
+++ b/website/blog/2022-05-19-whats-new-3.md
@@ -146,7 +146,7 @@ this fixes weird behaviour when using a transient prompt when your config result
 
 That's it for this time, see you for the next one 🤞🏻
 
-Keep that prompt posh everyone!
+_Keep that prompt posh everyone!_
 
 [module]: https://www.powershellgallery.com/packages/oh-my-posh/7.85.2
 [hurdles]: /docs/migrating#problem-statement
@@ -166,7 +166,7 @@ Keep that prompt posh everyone!
 [battery]: /docs/segments/system/battery
 [winget]: https://docs.microsoft.com/en-us/windows/package-manager/winget/
 [dotnet]: /docs/segments/languages/dotnet
-[iterm]: /docs/segments/system/iterm
-[memory]: /docs/segments/system/memory
+[iterm]: /docs/configuration/general#settings
+[memory]: /docs/segments/system/sysinfo#properties
 [exit]: /docs/segments/system/status
 [path]: /docs/segments/system/path

--- a/website/docs/configuration/colors.mdx
+++ b/website/docs/configuration/colors.mdx
@@ -294,7 +294,7 @@ cycle always gets precedence over everything else.
 
 [hexcolors]: https://htmlcolorcodes.com/color-chart/material-design-color-chart/
 [ansicolors]: https://htmlcolorcodes.com/color-chart/material-design-color-chart/
-[git]: /docs/segments/scm//git
+[git]: /docs/segments/scm/git
 [battery]: /docs/segments/system/battery
 [template-properties]: /docs/configuration/templates#global-properties
 [aws]: /docs/segments/cloud/aws

--- a/website/docs/segments/scm/fossil.mdx
+++ b/website/docs/segments/scm/fossil.mdx
@@ -67,5 +67,4 @@ Local changes use the following syntax:
 | `>`  | moved       |
 
 [fossil]: https://fossil-scm.org
-[templates]: /docs/config-templates
-[hyperlinks]: /docs/config-templates#custom
+[templates]: /docs/configuration/templates

--- a/website/docs/segments/scm/git.mdx
+++ b/website/docs/segments/scm/git.mdx
@@ -240,4 +240,4 @@ You can then use the `POSH_GIT_STRING` environment variable in a [text segment][
 [kraken-ref]: https://www.gitkraken.com/invite/nQmDPR9D
 [text]: /docs/segments/system/text
 [exclude_folders]: /docs/configuration/segment#include--exclude-folders
-[Jujutsu]: https://jj-vcs.github.io/jj/latest/
+[Jujutsu]: https://www.jj-vcs.dev/

--- a/website/docs/segments/scm/jujutsu.mdx
+++ b/website/docs/segments/scm/jujutsu.mdx
@@ -6,7 +6,7 @@ sidebar_label: Jujutsu
 
 ## What
 
-Display Jujutsu information when in a Jujutsu repository.
+Display [Jujutsu][jujutsu] information when in a Jujutsu repository.
 
 ## Sample Configuration
 
@@ -83,4 +83,5 @@ Local changes use the following syntax:
 | `+`  | Added       |
 | `>`  | Moved       |
 
-[templates]: /docs/config-templates
+[jujutsu]: https://www.jj-vcs.dev/
+[templates]: /docs/configuration/templates

--- a/website/docs/segments/scm/mercurial.mdx
+++ b/website/docs/segments/scm/mercurial.mdx
@@ -6,7 +6,7 @@ sidebar_label: Mercurial
 
 ## What
 
-Display Mercurial information when in a Mercurial repository. For maximum compatibility,
+Display [Mercurial][mercurial] information when in a Mercurial repository. For maximum compatibility,
 make sure your `hg` executable is up-to-date (when branch or status information is incorrect for example).
 
 ## Sample Configuration
@@ -81,4 +81,5 @@ Local changes use the following syntax:
 | `-`  | Deleted     |
 | `+`  | Added       |
 
-[templates]: /docs/config-templates
+[mercurial]: https://www.mercurial-scm.org
+[templates]: /docs/configuration/templates


### PR DESCRIPTION
## Summary by Sourcery

Fix broken and outdated links in documentation and blog posts.

Bug Fixes:
- Correct outdated or invalid documentation links for iTerm, memory/sysinfo, SCM templates, Git, and Jujutsu.
- Fix incorrect internal links and references in SCM segment docs for Jujutsu, Mercurial, and Fossil.
- Clean up minor markdown formatting issues in blog posts to ensure consistent emphasis styling.

Documentation:
- Update blog posts and SCM segment docs to use valid, up-to-date external URLs for Jujutsu and Mercurial.
- Align documentation links to the new configuration/templates paths across multiple SCM and configuration pages.