### PR TITLE
fix(docs): update broken link of go.mod

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,4 +81,4 @@ go test "./..."
 [codespaces-link]: <https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=175405157>
 [devcontainer-ext]: <https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers>
 [timezones]: <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>
-[go.mod]: src\go.mod
+[go.mod]: src/go.mod


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct the go.mod file link path in CONTRIBUTING.md so it uses the proper forward-slash notation.