### PR TITLE
feat: update linux mint icon

### DIFF
--- a/src/segments/os.go
+++ b/src/segments/os.go
@@ -73,7 +73,7 @@ func (oi *Os) getDistroIcon(distro string) string {
 		"kali":                "\uf327",
 		"mageia":              "\uF310",
 		"manjaro":             "\uF312",
-		"mint":                "\uF30e",
+		"mint":                "\U000f08ed",
 		"nixos":               "\uF313",
 		"opensuse":            "\uF314",
 		"opensuse-tumbleweed": "\uF314",

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -2765,7 +2765,7 @@
                     "type": "string",
                     "title": "FreeBSD Icon",
                     "description": "The icon to use for FreeBSD",
-                    "default": "\\U000f08e0"
+                    "default": "\udb82\udce0"
                   },
                   "gentoo": {
                     "type": "string",
@@ -2777,7 +2777,7 @@
                     "type": "string",
                     "title": "Kali Icon",
                     "description": "The icon to use for Kali",
-                    "default": "\\uf327"
+                    "default": "\uf327"
                   },
                   "mageia": {
                     "type": "string",
@@ -2795,13 +2795,13 @@
                     "type": "string",
                     "title": "Mint Icon",
                     "description": "The icon to use for Mint",
-                    "default": "\uf30e"
+                    "default": "\udb82\udced"
                   },
                   "neon": {
                     "type": "string",
                     "title": "Neon Icon",
                     "description": "The icon to use for Neon",
-                    "default": "\\uf331"
+                    "default": "\uf331"
                   },
                   "nixos": {
                     "type": "string",
@@ -2873,7 +2873,7 @@
                     "type": "string",
                     "title": "Android Icon",
                     "description": "The icon to use for Android",
-                    "default": "\\ue70e"
+                    "default": "\ue70e"
                   }
                 },
                 "additionalProperties": false

--- a/website/docs/segments/system/os.mdx
+++ b/website/docs/segments/system/os.mdx
@@ -27,43 +27,43 @@ import Config from "@site/src/components/Config.js";
 
 ## Options
 
-| Name                  |   Type    |   Default    | Description                                              |
-| --------------------- | :-------: | :----------: | -------------------------------------------------------- |
-| `macos`               | `string`  |   `\uF179`   | the string to use for macOS                              |
-| `linux`               | `string`  |   `\uF17C`   | the icon to use for Linux                                |
-| `windows`             | `string`  |   `\uE62A`   | the icon to use for Windows                              |
-| `display_distro_name` | `boolean` |   `false`    | display the distro name instead of icon for Linux or WSL |
-| `alma`                | `string`  |   `\uF31D`   | the icon to use for AlmaLinux OS                         |
-| `almalinux`           | `string`  |   `\uF31D`   | the icon to use for AlmaLinux OS                         |
-| `almalinux9`          | `string`  |   `\uF31D`   | the icon to use for AlmaLinux OS 9                       |
-| `alpine`              | `string`  |   `\uF300`   | the icon to use for Alpine Linux                         |
-| `android`             | `string`  |   `\ue70e`   | the icon to use for Android                              |
-| `aosc`                | `string`  |   `\uF301`   | the icon to use for AOSC OS                              |
-| `arch`                | `string`  |   `\uF303`   | the icon to use for Arch Linux                           |
-| `centos`              | `string`  |   `\uF304`   | the icon to use for CentOS                               |
-| `coreos`              | `string`  |   `\uF305`   | the icon to use for CoreOS Container Linux               |
-| `debian`              | `string`  |   `\uF306`   | the icon to use for Debian                               |
-| `deepin`              | `string`  |   `\uF321`   | the icon to use for deepin                               |
-| `devuan`              | `string`  |   `\uF307`   | the icon to use for Devuan GNU+Linux                     |
-| `elementary`          | `string`  |   `\uF309`   | the icon to use for elementary OS                        |
-| `endeavouros`         | `string`  |   `\uF322`   | the icon to use for EndeavourOS                          |
-| `fedora`              | `string`  |   `\uF30a`   | the icon to use for Fedora                               |
-| `freebsd`             | `string`  | `\U000f08e0` | the icon to use for FreeBSD                              |
-| `gentoo`              | `string`  |   `\uF30d`   | the icon to use for Gentoo Linux                         |
-| `kali`                | `string`  |   `\uf327`   | the icon to use for Kali Linux                           |
-| `mageia`              | `string`  |   `\uF310`   | the icon to use for Mageia                               |
-| `manjaro`             | `string`  |   `\uF312`   | the icon to use for Manjaro Linux                        |
-| `mint`                | `string`  |   `\uF30e`   | the icon to use for Linux Mint                           |
-| `neon`                | `string`  |   `\uf331`   | the icon to use for KDE neon                             |
-| `nixos`               | `string`  |   `\uF313`   | the icon to use for NixOS                                |
-| `opensuse`            | `string`  |   `\uF314`   | the icon to use for openSUSE                             |
-| `opensuse-tumbleweed` | `string`  |   `\uF314`   | the icon to use for openSUSE Tumbleweed                  |
-| `raspbian`            | `string`  |   `\uF315`   | the icon to use for Raspberry Pi OS (Raspbian)           |
-| `redhat`              | `string`  |   `\uF316`   | the icon to use for Red Hat Enterprise Linux (RHEL)      |
-| `rocky`               | `string`  |   `\uF32B`   | the icon to use for Rocky Linux                          |
-| `sabayon`             | `string`  |   `\uF317`   | the icon to use for Sabayon                              |
-| `slackware`           | `string`  |   `\uF319`   | the icon to use for Slackware Linux                      |
-| `ubuntu`              | `string`  |   `\uF31b`   | the icon to use for Ubuntu                               |
+| Name                  |   Type    |    Default     | Description                                              |
+| --------------------- | :-------: | :------------: | -------------------------------------------------------- |
+| `macos`               | `string`  |    `\uF179`    | the string to use for macOS                              |
+| `linux`               | `string`  |    `\uF17C`    | the icon to use for Linux                                |
+| `windows`             | `string`  |    `\uE62A`    | the icon to use for Windows                              |
+| `display_distro_name` | `boolean` |    `false`     | display the distro name instead of icon for Linux or WSL |
+| `alma`                | `string`  |    `\uF31D`    | the icon to use for AlmaLinux OS                         |
+| `almalinux`           | `string`  |    `\uF31D`    | the icon to use for AlmaLinux OS                         |
+| `almalinux9`          | `string`  |    `\uF31D`    | the icon to use for AlmaLinux OS 9                       |
+| `alpine`              | `string`  |    `\uF300`    | the icon to use for Alpine Linux                         |
+| `android`             | `string`  |    `\ue70e`    | the icon to use for Android                              |
+| `aosc`                | `string`  |    `\uF301`    | the icon to use for AOSC OS                              |
+| `arch`                | `string`  |    `\uF303`    | the icon to use for Arch Linux                           |
+| `centos`              | `string`  |    `\uF304`    | the icon to use for CentOS                               |
+| `coreos`              | `string`  |    `\uF305`    | the icon to use for CoreOS Container Linux               |
+| `debian`              | `string`  |    `\uF306`    | the icon to use for Debian                               |
+| `deepin`              | `string`  |    `\uF321`    | the icon to use for deepin                               |
+| `devuan`              | `string`  |    `\uF307`    | the icon to use for Devuan GNU+Linux                     |
+| `elementary`          | `string`  |    `\uF309`    | the icon to use for elementary OS                        |
+| `endeavouros`         | `string`  |    `\uF322`    | the icon to use for EndeavourOS                          |
+| `fedora`              | `string`  |    `\uF30a`    | the icon to use for Fedora                               |
+| `freebsd`             | `string`  | `\udb82\udce0` | the icon to use for FreeBSD                              |
+| `gentoo`              | `string`  |    `\uF30d`    | the icon to use for Gentoo Linux                         |
+| `kali`                | `string`  |    `\uf327`    | the icon to use for Kali Linux                           |
+| `mageia`              | `string`  |    `\uF310`    | the icon to use for Mageia                               |
+| `manjaro`             | `string`  |    `\uF312`    | the icon to use for Manjaro Linux                        |
+| `mint`                | `string`  | `\udb82\udced` | the icon to use for Linux Mint                           |
+| `neon`                | `string`  |    `\uf331`    | the icon to use for KDE neon                             |
+| `nixos`               | `string`  |    `\uF313`    | the icon to use for NixOS                                |
+| `opensuse`            | `string`  |    `\uF314`    | the icon to use for openSUSE                             |
+| `opensuse-tumbleweed` | `string`  |    `\uF314`    | the icon to use for openSUSE Tumbleweed                  |
+| `raspbian`            | `string`  |    `\uF315`    | the icon to use for Raspberry Pi OS (Raspbian)           |
+| `redhat`              | `string`  |    `\uF316`    | the icon to use for Red Hat Enterprise Linux (RHEL)      |
+| `rocky`               | `string`  |    `\uF32B`    | the icon to use for Rocky Linux                          |
+| `sabayon`             | `string`  |    `\uF317`    | the icon to use for Sabayon                              |
+| `slackware`           | `string`  |    `\uF319`    | the icon to use for Slackware Linux                      |
+| `ubuntu`              | `string`  |    `\uF31b`    | the icon to use for Ubuntu                               |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
## Summary by Sourcery

Update the Linux Mint OS segment icon and its documentation to use the new glyph.

Enhancements:
- Align the Linux Mint distro icon in code and docs with the updated glyph value.
- Normalize icon escape sequences in OS segment documentation for consistency.