### PR TITLE
docs(segments): add and update icons

### DIFF
--- a/website/docs/segments/cli/argocd.mdx
+++ b/website/docs/segments/cli/argocd.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#ffffff",
     background: "#FFA400",
-    template: " {{ .Name }}:{{ .User }}@{{ .Server }} ",
+    template: " \ue734 {{ .Name }}:{{ .User }}@{{ .Server }} ",
   }}
 />
 

--- a/website/docs/segments/cli/cmake.mdx
+++ b/website/docs/segments/cli/cmake.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#E8EAEE",
     background: "#1E9748",
-    template: " \ue61e \ue61d cmake {{ .Full }} ",
+    template: " \ue794 cmake {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/cli/deno.mdx
+++ b/website/docs/segments/cli/deno.mdx
@@ -17,7 +17,7 @@ import Config from "@site/src/components/Config.js";
     type: "deno",
     style: "plain",
     foreground: "#3C82F6",
-    template: " \ue628 {{ .Full }} ",
+    template: " \ue7c0 {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/cli/flutter.mdx
+++ b/website/docs/segments/cli/flutter.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#ffffff",
     background: "#06A4CE",
-    template: " \ue28e {{ .Full }} ",
+    template: " \ue7dd {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/cli/helm.mdx
+++ b/website/docs/segments/cli/helm.mdx
@@ -16,7 +16,7 @@ import Config from '@site/src/components/Config.js';
   "background": "#a7cae1",
   "foreground": "#100e23",
   "powerline_symbol": "\ue0b0",
-  "template": " Helm {{ .Version }}",
+  "template": " \ue7fb {{ .Version }}",
   "style": "powerline",
   "type": "helm"
 }}/>

--- a/website/docs/segments/cli/kubectl.mdx
+++ b/website/docs/segments/cli/kubectl.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#000000",
     background: "#ebcc34",
-    template: " \uFD31 {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} ",
+    template: " \udb84\udcfe {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} ",
     options: {
       context_aliases: {
         "arn:aws:eks:eu-west-1:1234567890:cluster/posh": "posh",

--- a/website/docs/segments/cli/mvn.mdx
+++ b/website/docs/segments/cli/mvn.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#FFFFFF",
     background: "#2E2A65",
-    template: " Maven {{ .Full }} ",
+    template: " \ue82c {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/cli/nix-shell.mdx
+++ b/website/docs/segments/cli/nix-shell.mdx
@@ -18,7 +18,7 @@ import Config from "@site/src/components/Config.js";
     style: "powerline",
     foreground: "blue",
     background: "transparent",
-    template: "(nix-{{ .Type }})",
+    template: "(\udb84\udd05-{{ .Type }})",
   }}
 />
 

--- a/website/docs/segments/cloud/gcp.mdx
+++ b/website/docs/segments/cloud/gcp.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#ffffff",
     background: "#47888d",
-    template: " \uE7B2 {{.Project}} :: {{.Account}} ",
+    template: " \udb84\uddf6 {{.Project}} :: {{.Account}} ",
   }}
 />
 

--- a/website/docs/segments/health/strava.mdx
+++ b/website/docs/segments/health/strava.mdx
@@ -49,7 +49,7 @@ import Config from "@site/src/components/Config.js";
       "{{ if and (lt .Hours 100) (gt .Hours 50) }}#343a40{{ end }}",
       "{{ if lt .Hours 50 }}#FFFFFF{{ end }}",
     ],
-    template: " {{.Name}} {{.Ago}} {{.Icon}} ",
+    template: " \ued52 {{.Name}} {{.Ago}} {{.Icon}} ",
     options: {
       access_token: "11111111111111111",
       refresh_token: "1111111111111111",

--- a/website/docs/segments/languages/crystal.mdx
+++ b/website/docs/segments/languages/crystal.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#ffffff",
     background: "#4063D8",
-    template: " \uE370 {{ .Full }} ",
+    template: " \ue62f {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/languages/kotlin.mdx
+++ b/website/docs/segments/languages/kotlin.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#ffffff",
     background: "#906cff",
-    template: " <b>K</b> {{ .Full }} ",
+    template: " \ue634 {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/languages/r.mdx
+++ b/website/docs/segments/languages/r.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "blue",
     background: "lightWhite",
-    template: " R {{ .Full }} ",
+    template: " \ue68a {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/scm/mercurial.mdx
+++ b/website/docs/segments/scm/mercurial.mdx
@@ -21,8 +21,9 @@ import Config from "@site/src/components/Config.js";
     foreground: "#193549",
     background: "#ffeb3b",
     options: {
-      newprop: "\uEFF1",
-    },
+      fetch_status: true,
+      native_fallback: false
+    }
   }}
 />
 

--- a/website/docs/segments/web/nba.mdx
+++ b/website/docs/segments/web/nba.mdx
@@ -12,7 +12,7 @@ favorite NBA team!
 ## Sample Configuration
 
 In order to use the NBA segment, you need to provide a valid team
-[tri-code](https://liaison.reuters.com/tools/sports-team-codes) that you'd
+[tri-code][tri-code] that you'd
 like to get data for inside of the configuration. For example, if you'd like
 to get information for the Los Angeles Lakers, you'd need to use the "LAL"
 tri-code.
@@ -21,7 +21,7 @@ This example uses "LAL" to get information for the Los Angeles Lakers. It also
 sets the foreground and background colors to match the theming for the team.
 If you are interested in getting information about specific foreground and
 background colors you could use for other teams, you can explore some of
-the color schemes [here](https://teamcolorcodes.com/nba-team-color-codes/).
+the color schemes [here][color-schemes].
 
 It is recommended that you set the HTTP timeout to a higher value than the
 normal default in case it takes some time to gather the scoreboard information.
@@ -57,7 +57,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-\U000F0806 {{ .HomeTeam}}{{ if .HasStats }} ({{.HomeTeamWins}}-{{.HomeTeamLosses}}){{ end }}{{ if .Started }}:{{.HomeScore}}{{ end }} vs {{ .AwayTeam}}{{ if .HasStats }} ({{.AwayTeamWins}}-{{.AwayTeamLosses}}){{ end }}{{ if .Started }}:{{.AwayScore}}{{ end }} | {{ if not .Started }}{{.GameDate}} | {{ end }}{{.Time}}
+\udb82\udc06 {{ .HomeTeam}}{{ if .HasStats }} ({{.HomeTeamWins}}-{{.HomeTeamLosses}}){{ end }}{{ if .Started }}:{{.HomeScore}}{{ end }} vs {{ .AwayTeam}}{{ if .HasStats }} ({{.AwayTeamWins}}-{{.AwayTeamLosses}}){{ end }}{{ if .Started }}:{{.AwayScore}}{{ end }} | {{ if not .Started }}{{.GameDate}} | {{ end }}{{.Time}}
 ```
 
 :::
@@ -81,5 +81,6 @@ import Config from "@site/src/components/Config.js";
 | .Started        | `boolean` | if the game was started or not                              |
 | .HasStats       | `boolean` | if the game has game stats or not                           |
 
+[color-schemes]: https://teamcolorcodes.com/nba-team-color-codes/
 [templates]: /docs/configuration/templates
-[nf-search]: https://www.nerdfonts.com/cheat-sheet
+[tri-code]: https://liaison.reuters.com/tools/sports-team-codes

--- a/website/docs/segments/web/owm.mdx
+++ b/website/docs/segments/web/owm.mdx
@@ -62,8 +62,6 @@ import Config from "@site/src/components/Config.js";
 | `.UnitIcon`    | `string` | the current unit icon(based on units property) |
 | `.URL`         | `string` | the url of the current api call                |
 
-[go-text-template]: https://golang.org/pkg/text/template/
-[sprig]: http://masterminds.github.io/sprig/
 [templates]: /docs/configuration/templates
 [owm]: https://openweathermap.org
 [owm-price]: https://openweathermap.org/price


### PR DESCRIPTION
## Summary by Sourcery

Update segment documentation to use new icons and cleaned-up references across CLI, language, health, cloud, SCM, and web segments.

Documentation:
- Refresh CLI, language, health, cloud, and SCM segment examples to use updated icons in their templates.
- Improve NBA segment docs by switching to reference-style links, adding missing link targets, and correcting existing references.
- Tidy OpenWeatherMap docs by removing unused template-related reference links.