### PR TITLE
docs(advanced): add a mcp-server document to sidebar

### DIFF
--- a/website/docs/advanced/mcp-server.mdx
+++ b/website/docs/advanced/mcp-server.mdx
@@ -71,7 +71,7 @@ curl -X POST https://ohmyposh.dev/api/mcp \
     "params": {
       "name": "validate_config",
       "arguments": {
-        "content": "{\"$schema\":\"https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json\",\"version\":3,\"blocks\":[]}",
+        "content": "{\"$schema\":\"https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json\",\"version\":4,\"blocks\":[]}",
         "format": "json"
       }
     },
@@ -137,7 +137,7 @@ Each error in the `errors` array contains:
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-  "version": 3,
+  "version": 4,
   "blocks": [
     {
       "type": "prompt",
@@ -213,7 +213,7 @@ oh-my-posh themes.
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-  "version": 3,
+  "version": 4,
   "blocks": []
 }
 ```
@@ -222,14 +222,14 @@ oh-my-posh themes.
 
 ```yaml
 $schema: https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json
-version: 3
+version: 4
 blocks: []
 ```
 
 ### TOML
 
 ```toml
-version = 3
+version = 4
 blocks = []
 ```
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -232,6 +232,14 @@ module.exports = {
     "dsc",
     "themes",
     "share",
+    {
+      type: "category",
+      label: "🛠️ Advanced",
+      collapsed: true,
+      items: [
+        "advanced/mcp-server",
+      ],
+    },
     "faq",
     "migrating",
     "contributors",


### PR DESCRIPTION
## Summary by Sourcery

Update MCP server documentation examples to use schema version 4 and expose the page under an Advanced section in the docs sidebar.

Documentation:
- Update MCP server documentation examples to reference theme schema version 4 instead of version 3.
- Add the MCP server documentation page to a new Advanced section in the docs sidebar.