### PR TITLE
docs(sidebar): remove a redundant getting started collapse

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -7,25 +7,18 @@ module.exports = {
       items: [
         {
           type: "category",
-          label: "🚀 Get started",
+          label: "📦 Installation",
           collapsed: false,
           items: [
-            {
-              type: "category",
-              label: "📦 Installation",
-              collapsed: false,
-              items: [
-                "installation/windows",
-                "installation/macos",
-                "installation/linux",
-              ],
-            },
-            "installation/fonts",
-            "installation/prompt",
-            "installation/customize",
-            "installation/upgrade",
+            "installation/windows",
+            "installation/macos",
+            "installation/linux",
           ],
         },
+        "installation/fonts",
+        "installation/prompt",
+        "installation/customize",
+        "installation/upgrade",
       ],
     },
     {


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Flatten the installation section in the docs sidebar by promoting installation guides and related pages to a single "Installation" category.