### PR TITLE
docs(installation): polish installation section

### DIFF
--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -38,7 +38,7 @@ and will download the configuration on shell start. Caching is in place, but for
 it's recommended to use a local configuration file.
 :::
 
-### Set the configuration
+## Set the configuration
 
 The example below uses a local path to the [jandedobbeleer][jandedobbeleer] theme, adjust the `--config` value
 to reflect your configuration file, local or remote.
@@ -115,7 +115,6 @@ exec elvish
 
 :::caution
 It is recommended to use the latest version of Fish. Versions below 4.1.0 have issues and do not support [transient prompt].
-
 :::
 
 Adjust the Oh My Posh init line in `~/.config/fish/config.fish` by adding the `--config` flag with
@@ -212,7 +211,7 @@ Windows user's home folder.
 Inside the WSL, you can find your Windows user's home folder here: `/mnt/c/Users/<WINDOWSUSERNAME>`.
 :::
 
-### Custom configuration
+## Custom configuration
 
 Maybe there's a theme you like, but you don't fancy the colors. Or, maybe there's a segment you
 want to tweak/add, or replace some of the icons with a different one. Whatever the case, **read through
@@ -225,7 +224,7 @@ which can be used to tweak and store as your own custom configuration.
 oh-my-posh config export --config jandedobbeleer --output ~/.mytheme.omp.json
 ```
 
-### Live reloading
+## Live reloading
 
 By default, the configuration is cached for performance reasons. If you make changes to your configuration file
 and want to see those changes reflected in your prompt without restarting your shell, you can use the following
@@ -241,7 +240,7 @@ You can disable live reload with:
 oh-my-posh disable reload
 ```
 
-#### Previewing changes
+### Previewing changes
 
 If you want to preview your changes, you can use the following command to render every configured prompt.
 
@@ -255,17 +254,14 @@ Use the `--force` flag in case you want to render all segments, regardless of th
 oh-my-posh print preview --force
 ```
 
-### Read the docs
+## Read the docs
 
 To fully understand how to customize a theme, read through the documentation in the configuration and segments sections.
 The [configuration][configuration] section covers the basic building blocks and concepts of Oh My Posh themes, while the
 segments section covers how to configure each available segment.
 
-[themes]: themes.md
 [configuration]: configuration/general.mdx
 [prompt]: prompt.mdx
 [jandedobbeleer]: /docs/themes#jandedobbeleer
-[json-schema]: https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json
-[homebrew-problem]: https://github.com/JanDeDobbeleer/oh-my-posh/discussions/2644
-[sign]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_signing?view=powershell-7.3#methods-of-signing-scripts
+[sign]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_signing?view=powershell-7.5#methods-of-signing-scripts
 [transient prompt]: /docs/configuration/transient

--- a/website/docs/installation/fonts.mdx
+++ b/website/docs/installation/fonts.mdx
@@ -7,7 +7,7 @@ sidebar_label: 🔤 Fonts
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-### Nerd Fonts
+## Nerd Fonts
 
 Oh My Posh was designed to use [Nerd Fonts][nerdfonts]. Nerd Fonts are popular fonts that are patched to include icons.
 To see the icons displayed in Oh My Posh, **install** a [Nerd Font][nerdfonts], and **configure** your terminal to use it.
@@ -18,13 +18,13 @@ This means **when running inside a container or WSL**, you need to install the f
 your terminal emulator to use it.
 :::
 
-### Installation
+## Installation
 
 <Tabs
     defaultValue="oh-my-posh"
     values={[
         { label: 'Oh My Posh', value: 'oh-my-posh' },
-        { label: 'homebrew', value: 'homebrew' },
+        { label: 'Homebrew', value: 'homebrew' },
         { label: 'PowerShell', value: 'powershell' }
     ]
 }>
@@ -42,7 +42,8 @@ By default, Oh My Posh installs the `.ttf` version of the font in case multiple 
 oh-my-posh font install
 ```
 
-This will present a list of Nerd Font libraries, from which you can  select `Meslo`, which includes the `Meslo LGM NF` font we recommend. Note that you can also  install it directly via:
+This will present a list of Nerd Font libraries, from which you can  select `Meslo`, which includes the
+`Meslo LGM NF` font we recommend. Note that you can also install it directly via:
 
 ```bash
 oh-my-posh font install meslo
@@ -80,7 +81,7 @@ Install-NerdFont -Name FiraCode -Scope AllUsers
 </TabItem>
 </Tabs>
 
-### Configuration
+## Configuration
 
 Make sure to **configure your terminal** to use the font you have installed. The following sections will show you how to do this for the most popular terminals.
 
@@ -151,7 +152,7 @@ The command has only been tested on macOS Sequoia 15.5 24F74.
 </TabItem>
 </Tabs>
 
-### Other Fonts
+## Other Fonts
 
 If you are not interested in using a Nerd Font, you will want to use a theme which doesn't include any Nerd Font icons.
 The `minimal` themes do not make use of Nerd Font icons.
@@ -161,5 +162,4 @@ The `minimal` themes do not make use of Nerd Font icons.
 [nerdfonts]: https://www.nerdfonts.com/
 [nerdfonts-ps]: https://psmodule.io/NerdFonts
 [configuration]: /docs/installation/customize
-[wt-issue-8993]: https://github.com/microsoft/terminal/issues/8993
 [vs-otf]: https://stackoverflow.com/questions/75252606/is-it-possible-to-use-nerd-fonts-as-the-font-for-terminals-in-visual-studio

--- a/website/docs/installation/homebrew.md
+++ b/website/docs/installation/homebrew.md
@@ -1,4 +1,5 @@
-A [Homebrew][brew] Formula and Cask (macOS only) are available for easy installation.
+<!-- markdownlint-disable-next-line MD041 -->
+A [Homebrew][brew] Formula and Cask are available for easy installation.
 
 ```bash
 brew install jandedobbeleer/oh-my-posh/oh-my-posh
@@ -17,8 +18,8 @@ For example in zsh:
 ```bash
 brew update && brew upgrade && exec zsh
 ```
+
 :::
 
 [brew]: https://brew.sh
-[themes]: https://ohmyposh.dev/docs/themes
 [strange]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/1287

--- a/website/docs/installation/linux.mdx
+++ b/website/docs/installation/linux.mdx
@@ -4,10 +4,7 @@ title: Linux
 sidebar_label: 🐧 Linux
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-import InstallHomebrew from "./homebrew.mdx";
-import Next from "./next.mdx";
+import Next from "./next.md";
 
 ## Set up your terminal
 

--- a/website/docs/installation/macos.mdx
+++ b/website/docs/installation/macos.mdx
@@ -4,9 +4,10 @@ title: macOS
 sidebar_label: 🍏 macOS
 ---
 
+import InstallHomebrew from "./homebrew.md";
+import Next from "./next.md";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Next from "./next.mdx";
 
 ## Set up your terminal
 
@@ -17,41 +18,24 @@ As the standard terminal only supports [256 colors][256-colors], we advise using
 To display all icons, we recommend the use of a [Nerd Font][fonts].
 :::
 
+## Installation
+
 <Tabs
   defaultValue="homebrew"
   groupId="install"
   values={[
-    { label: 'homebrew', value: 'homebrew', },
+    { label: 'Homebrew', value: 'homebrew', },
     { label: 'MacPorts', value: 'macports', }
   ]
 }>
 <TabItem value="homebrew">
 
-A [Homebrew][brew] Formula and Cask are available for easy installation.
-
-```bash
-brew install jandedobbeleer/oh-my-posh/oh-my-posh
-```
-
-Updating is done via:
-
-```bash
-brew update && brew upgrade oh-my-posh
-```
-
-:::tip
-In case you see [strange behaviour][strange] in your shell, reload it after upgrading Oh My Posh.
-For example in zsh:
-
-```bash
-brew update && brew upgrade && exec zsh
-```
-:::
+<InstallHomebrew />
 
 </TabItem>
 <TabItem value="macports">
 
-You can install Oh My Posh via [MacPorts] which is maintained by the [community].
+You can install Oh My Posh via [MacPorts] which is maintained by the [community][ports page].
 
 ```bash
 sudo port selfupdate
@@ -90,9 +74,5 @@ chsh -s "$(brew --prefix)/bin/bash" $USER
 [iterm2]: https://iterm2.com
 [fonts]: /docs/installation/fonts
 [MacPorts]: https://www.macports.org
-[ports page]: https://ports.macports.org/port/oh-my-posh
-[community]: https://ports.macports.org/port/oh-my-posh/
+[ports page]: https://ports.macports.org/port/oh-my-posh/
 [outdated-bash]: https://github.com/JanDeDobbeleer/oh-my-posh/discussions/3429
-[brew]: https://brew.sh
-[themes]: https://ohmyposh.dev/docs/themes
-[strange]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/1287

--- a/website/docs/installation/next.md
+++ b/website/docs/installation/next.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
 ## Next
 
 Now that Oh My Posh is installed, you can go ahead and configure your terminal and shell to

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -238,7 +238,6 @@ exec zsh
 </Tabs>
 
 [clink]: https://chrisant996.github.io/clink/
-[iterm2]: https://www.iterm2.com/
-[homebrew-problem]: https://github.com/JanDeDobbeleer/oh-my-posh/discussions/2644
+[iterm2]: https://iterm2.com/
 [sign]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_signing?view=powershell-7.3#methods-of-signing-scripts
 [transient prompt]: /docs/configuration/transient

--- a/website/docs/installation/upgrade.mdx
+++ b/website/docs/installation/upgrade.mdx
@@ -85,3 +85,4 @@ oh-my-posh enable upgrade
 </Tabs>
 
 [customize]: /docs/installation/customize#custom-configuration
+[time.ParseDuration]: https://golang.org/pkg/time/#ParseDuration

--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -1,13 +1,13 @@
 ---
 id: windows
 title: Windows
-sidebar_label:  🪟  Windows
+sidebar_label: 🪟 Windows
 ---
 
 import ThemedImage from '@theme/ThemedImage';
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Next from "./next.mdx";
+import Next from "./next.md";
 
 ## Set up your terminal
 
@@ -125,10 +125,7 @@ choco upgrade oh-my-posh
 </TabItem>
 </Tabs>
 
-
 [fonts]: /docs/installation/fonts
 [wt]: https://github.com/microsoft/terminal
 [linux]: /docs/installation/linux
-[themes]: /docs/themes
-[report-false-positive]: https://docs.microsoft.com/en-us/microsoft-365/security/defender/m365d-autoir-report-false-positives-negatives#report-a-false-positivenegative-to-microsoft-for-analysis
 [choco-maintainer]: https://github.com/digitalcoyote/chocolatey-packages

--- a/website/docs/segments/web/ipify.mdx
+++ b/website/docs/segments/web/ipify.mdx
@@ -51,5 +51,6 @@ import Config from "@site/src/components/Config.js";
 | ---- | -------- | ------------------------ |
 | .IP  | `string` | Your external IP address |
 
-[templates]: /docs/configuration/templates
 [ipify]: https://www.ipify.org/
+[templates]: /docs/configuration/templates
+[time.ParseDuration]: https://golang.org/pkg/time/#ParseDuration


### PR DESCRIPTION
## Summary by Sourcery

Polish and re-structure installation documentation across platforms, extracting shared Homebrew and "Next" content into reusable markdown includes and aligning headings, links, and references.

Documentation:
- Refine macOS, Linux, Windows, fonts, and customization installation pages to use consistent heading levels, tab labels, and wording.
- Extract Homebrew installation instructions and the "Next" section into standalone markdown files reused across platform docs.
- Update and correct various external links and reference targets, including PowerShell signing docs, iterm2, MacPorts, and template/timeout references.