### PR TITLE
ci: use DavidAnson markdown lint GitHub Actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!--  markdownlint-disable MD041 -->
 ### Prerequisites
 
 - [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
@@ -12,8 +13,9 @@
 Tips:
 
 If you're not comfortable with working with Git,
-we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
-Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.
+we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
+Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
+as your preferred cross platform Git GUI power tool.
 
 -->
 

--- a/.github/prompts/segment.prompt.md
+++ b/.github/prompts/segment.prompt.md
@@ -1,11 +1,11 @@
 ---
-description: "Generate a new Oh My Posh segment (code, registration, docs, schema, sidebar)"
-mode: 'agent'
-model: Claude Sonnet 4
-tools: ['githubRepo', 'codebase', 'createFile', 'editFiles', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'testFailure', 'usages']
+description: 'Generate a new Oh My Posh segment (code, registration, docs, schema, sidebar)'
+agent: 'agent'
+model: 'Claude Sonnet 4'
+tools: ['web/githubRepo', 'search/codebase', 'edit/createFile', 'edit/editFiles', 'read/problems', 'execute/getTerminalOutput', 'execute/runInTerminal', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/createAndRunTask', 'execute/runTask', 'read/getTaskOutput', 'execute/runTests', 'search', 'execute/testFailure', 'search/usages']
 ---
 
-## New Segment Prompt
+# New Segment Prompt
 
 Provide the inputs below. Keep this prompt minimal;
 the detailed steps live in `.instructions/segment.md`.

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -13,7 +13,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
     - name: Lint files
-      uses: articulate/actions-markdownlint@17b8abe7407cd17590c006ecc837c35e1ac3ed83
+      uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101
       with:
-          files: .
           config: .markdownlint.yaml
+          fix: true
+          globs: '**/*.{md,mdx}'


### PR DESCRIPTION
## Summary by Sourcery

Switch markdown linting to a new GitHub Action and align repo markdown configurations with it.

Enhancements:
- Update the AI segment prompt configuration to the new agent/tool schema used in the repository.

CI:
- Replace the existing markdownlint GitHub Action with DavidAnson/markdownlint-cli2-action and update its configuration inputs.

Documentation:
- Adjust PR template formatting to satisfy markdownlint rules and update the segment prompt markdown front matter and heading structure.