### PR TITLE
docs(docusaurus): add metastring prop for highlight code

### DIFF
--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -129,12 +129,10 @@ $env.SET_POSHCONTEXT = {
 <Config
   data={{
     version: 4,
-    // highlight-start
     var: {
       Hello: "hello",
       World: "world",
     },
-    // highlight-end
     blocks: [
       {
         type: "prompt",
@@ -144,12 +142,16 @@ $env.SET_POSHCONTEXT = {
             type: "text",
             style: "plain",
             foreground: "p:white",
-            // highlight-next-line
             template: "{{ .Var.Hello }} {{ .Var.World }} ",
           },
         ],
       },
     ],
+  }}
+  metastring={{
+    json: "{3-6,16}",
+    yaml: "{2-4,12}",
+    toml: "{3-5,15}",
   }}
 />
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -21,7 +21,7 @@ export default {
       respectPrefersColorScheme: true,
     },
     prism: {
-      additionalLanguages: ['powershell', 'lua', 'jsstacktrace', 'toml', 'json'],
+      additionalLanguages: ['powershell', 'lua', 'jsstacktrace', 'toml'],
     },
     docs: {
         sidebar: {

--- a/website/src/components/Config.js
+++ b/website/src/components/Config.js
@@ -7,7 +7,7 @@ import TOML from 'smol-toml';
 
 function Config(props) {
 
-  const {data} = props;
+  const { data, metastring = { json: "", yaml: "", toml: "" } } = props;
 
   const patchTomlData = () => {
     if (data?.properties) {
@@ -38,17 +38,17 @@ function Config(props) {
         ]
       }>
       <TabItem value="json">
-        <CodeBlock className="language-json">
+        <CodeBlock language="json" metastring={metastring.json}>
           {JSON.stringify(data, null, 2)}
         </CodeBlock>
       </TabItem>
       <TabItem value="yaml">
-        <CodeBlock className="language-yaml">
+        <CodeBlock language="yaml" metastring={metastring.yaml}>
           {YAML.stringify(data)}
         </CodeBlock>
       </TabItem>
       <TabItem value="toml">
-        <CodeBlock className="language-toml">
+        <CodeBlock language="toml" metastring={metastring.toml}>
           {TOML.stringify(patchTomlData())}
         </CodeBlock>
       </TabItem>


### PR DESCRIPTION
## Summary by Sourcery

Support metastring-based code highlighting for configuration examples in the Docusaurus docs.

New Features:
- Allow the Config documentation component to accept per-language metastrings and pass them through to Docusaurus CodeBlock for code highlighting.

Enhancements:
- Update the configuration templates documentation to use the new metastring prop instead of inline highlight comments.
- Simplify CodeBlock usage by switching from language-specific class names to the language and metastring props.

Build:
- Adjust Docusaurus Prism configuration by removing JSON from the list of additional languages, relying on the default support instead.

Documentation:
- Document metastring usage for highlighting JSON, YAML, and TOML configuration examples in the templates docs.