### PR TITLE
docs(contributing): polish contributing section

### DIFF
--- a/website/docs/contributing/segment.mdx
+++ b/website/docs/contributing/segment.mdx
@@ -140,10 +140,10 @@ import Config from "@site/src/components/Config.js";
 
 ## Options
 
-| Name               | Type      | Description                   | Default |
-| ------------------ | --------- | ----------------------------- | ------- |
-| `enable_new_thing` | `boolean` | Enables the new functionality | `false` |
-| `custom_text`      | `string`  | Custom text to display        | `""`    |
+| Name               | Type      | Default | Description                   |
+| ------------------ | --------- | ------- | ----------------------------- |
+| `enable_new_thing` | `boolean` | `false` | Enables the new functionality |
+| `custom_text`      | `string`  | `""`    | Custom text to display        |
 ```
 
 ## Step 4: Update Sidebar Navigation

--- a/website/docs/contributing/started.mdx
+++ b/website/docs/contributing/started.mdx
@@ -127,9 +127,9 @@ npm start
 
 This will start a local server on `http://localhost:3000` where you can see your changes.
 
-### Extra tips
+## Extra tips
 
-#### Configure Delve in VS Code
+### Configure Delve in VS Code
 
 [Delve][delve] config is restrictive by default(string limit especially). You can expand some limits in VS Code(`settings.json` or directly in `launch.json`):
 ```
@@ -155,9 +155,6 @@ With everything set up, you're ready to start making changes and create your fir
 [go-started]: https://go.dev/doc/
 [golang-ci-lint]: https://golangci-lint.run
 [golang-ci-lint-local]: https://golangci-lint.run/welcome/install/#local-installation
-[go-bindata]: https://github.com/kevinburke/go-bindata/
-[go-global]: https://github.com/golang/go/issues/40276
-[pr-go-mod]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/.github/workflows/gomod.yml
 [gh-pr]: https://github.com/JanDeDobbeleer/oh-my-posh/pulls
 [omp]: https://github.com/JanDeDobbeleer/oh-my-posh
 [gh-fork]: https://guides.github.com/activities/forking/


### PR DESCRIPTION
## Summary by Sourcery

Polish and clarify contributing documentation formatting.

Documentation:
- Reformat the options table in the Segment contributing doc for clearer column order.
- Adjust heading levels and remove unused reference links in the getting started contributing doc.