### PR TITLE
docs(dsc): use v3 powershell schema

### DIFF
--- a/website/docs/dsc.md
+++ b/website/docs/dsc.md
@@ -196,9 +196,8 @@ WinGet configuration enables you to install Oh My Posh and apply configuration i
 
 Create a configuration file to install and configure Oh My Posh:
 
-```yaml
-# oh-my-posh-setup.yaml
-$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+```yaml title="oh-my-posh-setup.yaml"
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/config/document.json
 metadata:
   winget:
     processor: dscv3
@@ -220,9 +219,8 @@ winget configure oh-my-posh-setup.yaml
 
 This example installs Oh My Posh, adds your configuration, and initializes PowerShell:
 
-```yaml
-# oh-my-posh-complete.yaml
-$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+```yaml title="oh-my-posh-complete.yaml"
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/config/document.json
 metadata:
   winget:
     processor: dscv3
@@ -258,9 +256,8 @@ winget configure oh-my-posh-complete.yaml
 
 Initialize multiple shells with different configurations:
 
-```yaml
-# oh-my-posh-multi-shell.yaml
-$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+```yaml title="oh-my-posh-multi-shell.yaml"
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/config/document.json
 metadata:
   winget:
     processor: dscv3
@@ -309,8 +306,7 @@ resources that can be used in DSC configuration documents.
 
 Create a configuration document for Oh My Posh:
 
-```yaml
-# oh-my-posh-dsc.yaml
+```yaml title="oh-my-posh-dsc.yaml"
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Add Oh My Posh configuration
@@ -336,8 +332,7 @@ dsc config set --document oh-my-posh-dsc.yaml
 
 ### Complete configuration with multiple shells
 
-```yaml
-# oh-my-posh-complete-dsc.yaml
+```yaml title="oh-my-posh-complete-dsc.yaml"
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Add primary configuration


### PR DESCRIPTION
## Summary by Sourcery

Update DSC documentation examples to use the v3 PowerShell schema and improve YAML code block metadata.

Documentation:
- Switch DSC YAML examples to reference the v3 PowerShell configuration schema URLs.
- Add descriptive titles to DSC YAML code blocks for clearer documentation examples.