### PR TITLE
docs(dsc): use v3 powershell schema

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,7 +67,7 @@ jobs:
         uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ASHY_MEADOW_063E9BA03 }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for GitHub integrations (i.e. PR comments)
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -681,7 +681,7 @@ func TestGitUpstream(t *testing.T) {
 		{Case: "SSH url", Expected: "G", Upstream: "ssh://git@git.my.domain:3001/ADIX7/dotconfig.git"},
 		{Case: "Gitea", Expected: "EX", Upstream: "_gitea@src.example.com:user/repo.git"},
 		{Case: "GitHub", Expected: "GH", Upstream: "github.com/test"},
-		{Case: "Gitlab", Expected: "GL", Upstream: "gitlab.com/test"},
+		{Case: "GitLab", Expected: "GL", Upstream: "gitlab.com/test"},
 		{Case: "Bitbucket", Expected: "BB", Upstream: "bitbucket.org/test"},
 		{Case: "Azure DevOps", Expected: "AD", Upstream: "dev.azure.com/test"},
 		{Case: "Azure DevOps Dos", Expected: "AD", Upstream: "test.visualstudio.com"},

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1829,14 +1829,14 @@
                   },
                   "github_icon": {
                     "type": "string",
-                    "title": "Github Icon",
-                    "description": "Icon/text to display when the upstream is Github",
+                    "title": "GitHub Icon",
+                    "description": "Icon/text to display when the upstream is GitHub",
                     "default": "\uf408"
                   },
                   "gitlab_icon": {
                     "type": "string",
-                    "title": "Gitlab Icon",
-                    "description": "Icon/text to display when the upstream is Gitlab",
+                    "title": "GitLab Icon",
+                    "description": "Icon/text to display when the upstream is GitLab",
                     "default": "\uf296"
                   },
                   "bitbucket_icon": {

--- a/website/docs/contributing/started.mdx
+++ b/website/docs/contributing/started.mdx
@@ -9,10 +9,10 @@ import TabItem from "@theme/TabItem";
 
 ## Get the source code
 
-The source is hosted on [Github][omp]. When you want to contribute, create a [fork][gh-fork] so you can make changes in
+The source is hosted on [GitHub][omp]. When you want to contribute, create a [fork][gh-fork] so you can make changes in
 your repository and create a pull request in the official Oh My Posh repository.
 
-To clone your fork of Oh My Posh locally, open the terminal and replace `<user>` with your Github username.
+To clone your fork of Oh My Posh locally, open the terminal and replace `<user>` with your GitHub username.
 
 ```powershell
 git clone git@github.com:<user>/oh-my-posh.git

--- a/website/docs/dsc.md
+++ b/website/docs/dsc.md
@@ -196,9 +196,8 @@ WinGet configuration enables you to install Oh My Posh and apply configuration i
 
 Create a configuration file to install and configure Oh My Posh:
 
-```yaml
-# oh-my-posh-setup.yaml
-$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+```yaml title="oh-my-posh-setup.yaml"
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/config/document.json
 metadata:
   winget:
     processor: dscv3
@@ -220,9 +219,8 @@ winget configure oh-my-posh-setup.yaml
 
 This example installs Oh My Posh, adds your configuration, and initializes PowerShell:
 
-```yaml
-# oh-my-posh-complete.yaml
-$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+```yaml title="oh-my-posh-complete.yaml"
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/config/document.json
 metadata:
   winget:
     processor: dscv3
@@ -258,9 +256,8 @@ winget configure oh-my-posh-complete.yaml
 
 Initialize multiple shells with different configurations:
 
-```yaml
-# oh-my-posh-multi-shell.yaml
-$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+```yaml title="oh-my-posh-multi-shell.yaml"
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/config/document.json
 metadata:
   winget:
     processor: dscv3
@@ -309,8 +306,7 @@ resources that can be used in DSC configuration documents.
 
 Create a configuration document for Oh My Posh:
 
-```yaml
-# oh-my-posh-dsc.yaml
+```yaml title="oh-my-posh-dsc.yaml"
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Add Oh My Posh configuration
@@ -336,8 +332,7 @@ dsc config set --document oh-my-posh-dsc.yaml
 
 ### Complete configuration with multiple shells
 
-```yaml
-# oh-my-posh-complete-dsc.yaml
+```yaml title="oh-my-posh-complete-dsc.yaml"
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
   - name: Add primary configuration

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -10,7 +10,7 @@ import Config from "@site/src/components/Config.js";
 
 Before validating anything, make sure you're on the [latest version][latest] of Oh My Posh and your terminal and shell are up-to-date.
 
-### My prompt is broken after upgrading to PowerShell 7.4
+## My prompt is broken after upgrading to PowerShell 7.4
 
 PowerShell 7.4 has an [issue][pwsh-20733] in encoding which affects the rendering of Oh My Posh.
 You can work around this by forcing the entire shell to UTF8.
@@ -25,7 +25,7 @@ Forcing the entire session to UTF8 can have unwanted side effects for other exec
 consider this a temporary workaround until the original PowerShell [issue][pwsh-20733] is resolved.
 :::
 
-### I want to disable the upgrade notice
+## I want to disable the upgrade notice
 
 You can disable the upgrade notice using the following command once:
 
@@ -39,7 +39,7 @@ If you want to enable it again, run:
 oh-my-posh enable notice
 ```
 
-### The prompt is slow (delay in showing the prompt between commands)
+## The prompt is slow (delay in showing the prompt between commands)
 
 :::tip Windows
 The delay you're experiencing may be linked to the real-time protection features of antivirus software.
@@ -94,14 +94,14 @@ If only your Git repo paths are slow, then try running [`git gc`][git-gc] to cle
 
 If nothing seems to resolve the issue, feel free to [create an issue][new-issue].
 
-### There are rectangles instead of icons in my prompt
+## There are rectangles instead of icons in my prompt
 
 The font you're using doesn't have the needed standard extended glyph set like [Nerd Font][nf] does.
 Windows Terminal ships with Cascadia Code by default which has a powerline patched variant called Cascadia Code PL,
 but also that one misses certain interesting icons. You can fall back to any theme with the `.minimal` indication,
 or make use of a Nerd Font. Have a look at the [font][font] section for more context in case you're using all the right conditions.
 
-### Text decoration styles like bold and dimmed don't work
+## Text decoration styles like bold and dimmed don't work
 
 The text decoration styles are based on your terminal emulator's capabilities.
 
@@ -111,7 +111,7 @@ Refer [this page on ArchWiki][arch-terminfo].
 If you are on Windows, use Windows Terminal. It closely copies the `xterm-256color` capabilities.
 See the [PowerShell docs on terminal support][ps-ansi-docs] and [this GitHub comment][xterm-gh-comment].
 
-### Windows Terminal: Unexpected space between segments/text
+## Windows Terminal: Unexpected space between segments/text
 
 Windows Terminal has some issues with [rendering certain glyphs][wt-glyph]. These issues are on [their backlog][wt-glyphs].
 A temporary workaround is to use an invisible character at the end (`\u2800`), or a zero width character (`\u200a`) before the icon.
@@ -137,17 +137,17 @@ Adjust it by adding `\u2800` immediately after the icon.
   }}
 />
 
-### Jetbrains terminals: Icons do not render
+## Jetbrains terminals: Icons do not render
 
 They need to work on their terminal, somehow it only supports UTF-8 and not UTF-16.
 [An issue][jb-icons] is available for a follow-up here.
 
-### Strange colouring after exiting VIM or when using the PowerShell progress bootstrap
+## Strange colouring after exiting VIM or when using the PowerShell progress bootstrap
 
 This bug is caused by Windows Terminal and/or VIM. There are two issues for this, one at [Windows Terminal][wt-vim] and
 one at [VIM][vim-wt].
 
-### Conda: environment name displayed in front of the prompt
+## Conda: environment name displayed in front of the prompt
 
 Conda will automatically prepend the prompt with the name of the environment you're in.
 To solely rely on Oh My Posh to set the prompt, you can configure the following setting to hide it.
@@ -157,7 +157,7 @@ Make sure to add this **before** initializing Oh My Posh.
 conda config --set changeps1 False
 ```
 
-### Python venv: Prompt changes on activating virtual environment
+## Python venv: Prompt changes on activating virtual environment
 
 Virtual environments created with `venv` add the active environment's name to the prompt automatically.
 To disable this behaviour, set `VIRTUAL_ENV_DISABLE_PROMPT` environment variable to `1` on your system. Example files:
@@ -200,11 +200,11 @@ export VIRTUAL_ENV_DISABLE_PROMPT=1
 </TabItem>
 </Tabs>
 
-### PowerShell: The term 'Set-Theme' is not recognized as the name of a cmdlet, function, script file, or operable program.
+## PowerShell: The term 'Set-Theme' is not recognized as the name of a cmdlet, function, script file, or operable program.
 
 You need to migrate using the following [guide][migrating].
 
-### PowerShell: Running in ConstrainedLanguage mode
+## PowerShell: Running in ConstrainedLanguage mode
 
 You're here because you've seen the following message:
 
@@ -224,7 +224,7 @@ To remove the message after manual configuration, you can add the following to y
 $env:POSH_CONSTRAINED_LANGUAGE = 1
 ```
 
-### PowerShell: The term '.../oh-my-posh.exe' is not recognized as a name of a cmdlet...
+## PowerShell: The term '.../oh-my-posh.exe' is not recognized as a name of a cmdlet...
 
 For example:
 
@@ -264,7 +264,7 @@ Alternatively, let the whole shell become UTF-8. (Be aware: Unwanted side effect
 $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 ```
 
-### Zsh: No command history (Ctrl+R does not work)
+## Zsh: No command history (Ctrl+R does not work)
 
 This issue occurs when you're using plain zsh in combination with Oh My Posh.
 You can fix this by adding the right configuration to `~/.zshrc`.
@@ -276,11 +276,11 @@ SAVEHIST=10000
 setopt appendhistory
 ```
 
-### ZSH: No such shell function 'zle-line-init'
+## ZSH: No such shell function 'zle-line-init'
 
 This is most likely caused by two Oh My Posh init lines in your `.zshrc`, remove one of them. See [here][zsh-init].
 
-### Fish: Display current bind (Vim) mode
+## Fish: Display current bind (Vim) mode
 
 By default, Oh My Posh will not re-render the prompt (i.e., generate a new prompt) until a new command is run, so you should
 export `$fish_bind_mode` to `FISH__BIND_MODE` and call the `omp_repaint_prompt` function to do prompt re-rendering when
@@ -313,7 +313,7 @@ After that, you can use the value in a template. The following replicates the [e
   }}
 />
 
-### Fish: Integrate with `Alt+←` and `Alt+→` Bindings to `prevd` and `nextd`
+## Fish: Integrate with `Alt+←` and `Alt+→` Bindings to `prevd` and `nextd`
 
 Fish supports using `Alt+←` (Alt+Left) and `Alt+→` (Alt+Right) bindings to [navigate the directory history](https://fishshell.com/docs/current/interactive.html#id13).
 
@@ -325,7 +325,7 @@ function rerender_on_dir_change --on-variable PWD
 end
 ```
 
-### After updating my Nerd Font to a newer version, the prompt displays unknown characters
+## After updating my Nerd Font to a newer version, the prompt displays unknown characters
 
 Nerd Fonts moved the icons to a different location in the font for v3.
 This can cause the prompt to display unknown characters. There's a built-in migration in Oh My Posh to fix this.
@@ -339,7 +339,7 @@ oh-my-posh config migrate glyphs --write
 This will update your configuration file to use the new glyph locations. Do know they might look different, as they also
 updated the icons themselves. A backup of the current config can be found in the same location with a `.bak` extension.
 
-### Xonsh: Right prompt jumps to bottom of the screen
+## Xonsh: Right prompt jumps to bottom of the screen
 
 This is a known problem with Xonsh. The issue is tracked [here][xonsh-issue].
 
@@ -362,7 +362,6 @@ This is a known problem with Xonsh. The issue is tracked [here][xonsh-issue].
 [wt-vim]: https://github.com/microsoft/terminal/issues/3794
 [vim-wt]: https://github.com/vim/vim/issues/5092
 [utf-8]: https://github.com/PowerShell/PowerShell/issues/7233#issuecomment-640243647
-[fish-changelog]: https://fishshell.com/docs/current/relnotes.html#id1
 [xonsh-issue]: https://github.com/xonsh/xonsh/issues/3810
 [zsh-init]: https://github.com/JanDeDobbeleer/oh-my-posh/discussions/3462#discussioncomment-5155790
 [fish-mode-prompt]: https://fishshell.com/docs/current/cmds/fish_mode_prompt.html#example

--- a/website/docs/segments/scm/git.mdx
+++ b/website/docs/segments/scm/git.mdx
@@ -95,8 +95,8 @@ You can set the following options to `true` to enable fetching additional inform
 
 | Name                |        Type         | Default  | Description                                                                                                                                                                  |
 | ------------------- | :-----------------: | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `github_icon`       |      `string`       | `\uF408` | icon/text to display when the upstream is Github                                                                                                                             |
-| `gitlab_icon`       |      `string`       | `\uF296` | icon/text to display when the upstream is Gitlab                                                                                                                             |
+| `github_icon`       |      `string`       | `\uF408` | icon/text to display when the upstream is GitHub                                                                                                                             |
+| `gitlab_icon`       |      `string`       | `\uF296` | icon/text to display when the upstream is GitLab                                                                                                                             |
 | `bitbucket_icon`    |      `string`       | `\uF171` | icon/text to display when the upstream is Bitbucket                                                                                                                          |
 | `azure_devops_icon` |      `string`       | `\uEBE8` | icon/text to display when the upstream is Azure DevOps                                                                                                                       |
 | `codecommit_icon`   |      `string`       | `\uF270` | icon/text to display when the upstream is AWS CodeCommit                                                                                                                     |

--- a/website/docs/share-theme.md
+++ b/website/docs/share-theme.md
@@ -47,6 +47,8 @@ override colors, set the author name, and specify the background color.
 
 ### Settings Options
 
+<!-- markdownlint-disable MD013 -->
+
 | Name               | Type     | Default   | Description                                                                   |
 | ------------------ | -------- | --------- | ----------------------------------------------------------------------------- |
 | `colors`           | `object` |           | Map of ANSI color names to hex color codes. See [16 ANSI color names][colors] |
@@ -54,6 +56,8 @@ override colors, set the author name, and specify the background color.
 | `background_color` | `string` | `#151515` | Hex code for the image background                                             |
 | `fonts`            | `object` |           | Font settings for the image, including regular, bold, and italic styles       |
 | `cursor`           | `string` | `_`       | A custom cursor                                                               |
+
+<!-- markdownlint-enable MD013 -->
 
 ### Usage
 

--- a/website/docs/themes.md
+++ b/website/docs/themes.md
@@ -5,9 +5,9 @@ sidebar_label: 🎨 Themes
 ---
 
 Oh My Posh comes with many themes included out-of-the-box. Below are some screenshots of the more common themes.
-For the full updated list of themes, [view the themes][themes] in Github.
+For the full updated list of themes, [view the themes][themes] in GitHub.
 
-Once you're ready to swap to a theme, follow the steps described in [🚀 Get started > Customize][installation-customize].
+Once you're ready to swap to a theme, follow the steps described in [💡 Getting started > Customize][installation-customize].
 
 Themes with `minimal` in their names do not require a Nerd Font. Read about [🆎Fonts][fonts] for more information.
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   docs: [
     {
       type: "category",

--- a/website/src/pages/privacy.mdx
+++ b/website/src/pages/privacy.mdx
@@ -22,6 +22,3 @@ We do not collect any personally identifiable information.
 Oh My Posh does not collect, transmit, distribute or sell your data.
 
 [ai]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#trackevent
-
-
-


### PR DESCRIPTION
## Summary by Sourcery

Update documentation and configuration examples for DSC v3 while polishing docs formatting and naming consistency across the project.

Build:
- Switch Docusaurus sidebar configuration to an ES module default export for compatibility with the current build setup.

CI:
- Correct a workflow comment to reference GitHub integrations consistently.

Documentation:
- Refresh DSC configuration examples to use the v3 PowerShell DSC schema and add titled YAML code blocks.
- Normalize headings, capitalization (e.g., GitHub/GitLab), and internal links across various documentation pages.
- Adjust share-theme and FAQ docs to respect markdown linting and improve readability of configuration tables.

Tests:
- Align Git upstream test case naming with updated GitLab capitalization.