### PR TITLE
docs(cloud): update a cloud segment info

### DIFF
--- a/src/segments/pulumi.go
+++ b/src/segments/pulumi.go
@@ -50,7 +50,7 @@ type pulumiWorkSpaceFileSpec struct {
 }
 
 func (p *Pulumi) Template() string {
-	return "\U000f0d46 {{ .Stack }}{{if .User }} :: {{ .User }}@{{ end }}{{ if .URL }}{{ .URL }}{{ end }}"
+	return "\ue873 {{ .Stack }}{{if .User }} :: {{ .User }}@{{ end }}{{ if .URL }}{{ .URL }}{{ end }}"
 }
 
 func (p *Pulumi) Enabled() bool {

--- a/src/segments/pulumi_test.go
+++ b/src/segments/pulumi_test.go
@@ -42,7 +42,7 @@ func TestPulumi(t *testing.T) {
 		},
 		{
 			Case:            "pulumi file YAML is present",
-			ExpectedString:  "\U000f0d46",
+			ExpectedString:  "\ue873",
 			ExpectedEnabled: true,
 			HasCommand:      true,
 			YAMLConfig: `
@@ -53,14 +53,14 @@ description: A Console App
 		},
 		{
 			Case:            "pulumi file JSON is present",
-			ExpectedString:  "\U000f0d46",
+			ExpectedString:  "\ue873",
 			ExpectedEnabled: true,
 			HasCommand:      true,
 			JSONConfig:      `{ "name": "oh-my-posh" }`,
 		},
 		{
 			Case:               "no stack present",
-			ExpectedString:     "\U000f0d46 1337",
+			ExpectedString:     "\ue873 1337",
 			ExpectedEnabled:    true,
 			HasCommand:         true,
 			HasWorkspaceFolder: true,
@@ -70,7 +70,7 @@ description: A Console App
 		},
 		{
 			Case:               "pulumi stack",
-			ExpectedString:     "\U000f0d46 1337",
+			ExpectedString:     "\ue873 1337",
 			ExpectedEnabled:    true,
 			HasCommand:         true,
 			HasWorkspaceFolder: true,
@@ -80,7 +80,7 @@ description: A Console App
 		},
 		{
 			Case:               "pulumi URL",
-			ExpectedString:     "\U000f0d46 1337 :: posh-user@s3://test-pulumi-state-test",
+			ExpectedString:     "\ue873 1337 :: posh-user@s3://test-pulumi-state-test",
 			ExpectedEnabled:    true,
 			HasCommand:         true,
 			HasWorkspaceFolder: true,
@@ -93,7 +93,7 @@ description: A Console App
 		// Error flows
 		{
 			Case:            "pulumi file JSON error",
-			ExpectedString:  "\U000f0d46",
+			ExpectedString:  "\ue873",
 			ExpectedEnabled: true,
 			FetchStack:      true,
 			HasCommand:      true,
@@ -101,7 +101,7 @@ description: A Console App
 		},
 		{
 			Case:               "pulumi workspace file JSON error",
-			ExpectedString:     "\U000f0d46",
+			ExpectedString:     "\ue873",
 			ExpectedEnabled:    true,
 			FetchStack:         true,
 			HasCommand:         true,
@@ -111,7 +111,7 @@ description: A Console App
 		},
 		{
 			Case:            "pulumi URL, no fetch_stack set",
-			ExpectedString:  "\U000f0d46",
+			ExpectedString:  "\ue873",
 			ExpectedEnabled: true,
 			HasCommand:      true,
 			FetchAbout:      true,
@@ -119,7 +119,7 @@ description: A Console App
 		},
 		{
 			Case:               "pulumi URL - about error",
-			ExpectedString:     "\U000f0d46 1337",
+			ExpectedString:     "\ue873 1337",
 			ExpectedEnabled:    true,
 			HasCommand:         true,
 			HasWorkspaceFolder: true,
@@ -131,7 +131,7 @@ description: A Console App
 		},
 		{
 			Case:               "pulumi URL - about decode error",
-			ExpectedString:     "\U000f0d46 1337",
+			ExpectedString:     "\ue873 1337",
 			ExpectedEnabled:    true,
 			HasCommand:         true,
 			HasWorkspaceFolder: true,
@@ -143,7 +143,7 @@ description: A Console App
 		},
 		{
 			Case:               "pulumi URL - about backend is nil",
-			ExpectedString:     "\U000f0d46 1337",
+			ExpectedString:     "\ue873 1337",
 			ExpectedEnabled:    true,
 			HasCommand:         true,
 			HasWorkspaceFolder: true,

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -738,18 +738,23 @@
             "description": "https://ohmyposh.dev/docs/segments/cloud/azfunc",
             "properties": {
               "options": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/language_options"
+                  }
+                ],
                 "properties": {
-                  "home_enabled": {
-                    "$ref": "#/definitions/home_enabled"
+                  "extensions": {
+                    "default": [
+                      "host.json",
+                      "local.settings.json",
+                      "function.json"
+                    ]
                   },
-                  "fetch_version": {
-                    "$ref": "#/definitions/fetch_version"
-                  },
-                  "display_mode": {
-                    "$ref": "#/definitions/display_mode"
-                  },
-                  "missing_command_text": {
-                    "$ref": "#/definitions/missing_command_text"
+                  "tooling": {
+                    "default": [
+                      "func"
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -1088,6 +1093,11 @@
                       ".cdsrc-private.json",
                       "*.cds"
                     ]
+                  },
+                  "tooling": {
+                    "default": [
+                      "cds"
+                    ]
                   }
                 }
               }
@@ -1118,6 +1128,11 @@
                       "manifest.yml",
                       "mta.yaml"
                     ]
+                  },
+                  "tooling": {
+                    "default": [
+                      "cf"
+                    ]
                   }
                 }
               }
@@ -1139,14 +1154,23 @@
               "options": {
                 "properties": {
                   "display_mode": {
-                    "type": "string",
-                    "title": "Display Mode",
-                    "description": "Determines whether the segment is displayed always or only if a file matching the extensions are present in the current folder",
+                    "$ref": "#/definitions/display_mode",
                     "enum": [
                       "always",
                       "files"
                     ],
                     "default": "always"
+                  },
+                  "files": {
+                    "type": "array",
+                    "title": "Files",
+                    "description": "The files to display in the segment",
+                    "default": [
+                      "manifest.yml"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 },
                 "additionalProperties": false
@@ -1443,7 +1467,11 @@
               "options": {
                 "properties": {
                   "display_mode": {
-                    "$ref": "#/definitions/display_mode"
+                    "$ref": "#/definitions/display_mode",
+                    "enum": [
+                      "files",
+                      "context"
+                    ]
                   },
                   "extensions": {
                     "default": [
@@ -2035,7 +2063,12 @@
               "options": {
                 "properties": {
                   "display_mode": {
-                    "$ref": "#/definitions/display_mode"
+                    "$ref": "#/definitions/display_mode",
+                    "enum": [
+                      "always",
+                      "files"
+                    ],
+                    "default": "always"
                   }
                 },
                 "additionalProperties": false
@@ -2537,7 +2570,7 @@
                     "type": "integer",
                     "title": "Http request timeout",
                     "description": "Milliseconds to use for http request timeouts",
-                    "default": 500
+                    "default": 20
                   },
                   "headers": {
                     "type": "object",
@@ -3938,12 +3971,6 @@
             "properties": {
               "options": {
                 "properties": {
-                  "url": {
-                    "type": "string",
-                    "title": "URL of API with Strava data",
-                    "description": "Url of your api provinding a Strava activity",
-                    "default": ""
-                  },
                   "ride_icon": {
                     "type": "string",
                     "title": "Ride icon",

--- a/website/docs/segments/cloud/aws.mdx
+++ b/website/docs/segments/cloud/aws.mdx
@@ -6,7 +6,7 @@ sidebar_label: AWS
 
 ## What
 
-Display the currently active AWS profile and region.
+Display the currently active [AWS][aws] profile and region.
 
 ## Sample Configuration
 
@@ -34,7 +34,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}
+ {{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}
 ```
 
 :::
@@ -48,3 +48,4 @@ import Config from "@site/src/components/Config.js";
 | `.RegionAlias`  | `string` | short alias for the currently active region |
 
 [templates]: /docs/configuration/templates
+[aws]: https://aws.amazon.com/

--- a/website/docs/segments/cloud/az.mdx
+++ b/website/docs/segments/cloud/az.mdx
@@ -6,7 +6,7 @@ sidebar_label: Azure
 
 ## What
 
-Display the currently active Azure subscription information.
+Display the currently active [Azure][azure] subscription information.
 
 ## Sample Configuration
 
@@ -59,4 +59,5 @@ import Config from "@site/src/components/Config.js";
 | `.Origin`            | `string`  | where we received the information from, can be `CLI` or `PWSH` |
 
 [templates]: /docs/configuration/templates
+[azure]: https://azure.microsoft.com
 [az]: https://www.powershellgallery.com/packages/Az

--- a/website/docs/segments/cloud/azd.mdx
+++ b/website/docs/segments/cloud/azd.mdx
@@ -6,7 +6,7 @@ sidebar_label: Azure Dev CLI
 
 ## What
 
-Display the currently active environment in the Azure Developer CLI.
+Display the currently active environment in the [Azure Developer CLI][azd].
 
 ## Sample Configuration
 

--- a/website/docs/segments/cloud/gcp.mdx
+++ b/website/docs/segments/cloud/gcp.mdx
@@ -6,7 +6,7 @@ sidebar_label: GCP
 
 ## What
 
-Display the currently active GCP project, region and account
+Display the currently active [GCP][gcp] project, region and account
 
 ## Sample Configuration
 
@@ -44,3 +44,4 @@ import Config from "@site/src/components/Config.js";
 | `.Error`        | `string` | contains any error messages generated when trying to load the GCP config |
 
 [templates]: /docs/configuration/templates
+[gcp]: https://cloud.google.com/

--- a/website/docs/segments/cloud/pulumi.mdx
+++ b/website/docs/segments/cloud/pulumi.mdx
@@ -6,7 +6,7 @@ sidebar_label: Pulumi
 
 ## What
 
-Display the currently active pulumi logged-in user, url and stack.
+Display the currently active [Pulumi][pulumi] logged-in user, url and stack.
 
 :::caution
 This requires a pulumi binary in your PATH and will only show in directories that contain a `Pulumi.yaml` file.
@@ -20,11 +20,11 @@ import Config from "@site/src/components/Config.js";
   data={{
     type: "pulumi",
     style: "diamond",
-    powerline_symbol: "\uE0CF",
+    powerline_symbol: "\uE0B0",
     foreground: "#ffffff",
     background: "#662d91",
     template:
-      "{{ .Stack }}{{if .User }} :: {{ .User }}@{{ end }}{{ if .URL }}{{ .URL }}{{ end }}",
+      "\ue873 {{ .Stack }}{{if .User }} :: {{ .User }}@{{ end }}{{ if .URL }}{{ .URL }}{{ end }}",
   }}
 />
 
@@ -40,7 +40,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ .Stack }}{{if .User }} :: {{ .User }}@{{ end }}{{ if .URL }}{{ .URL }}{{ end }}
+\ue873 {{ .Stack }}{{if .User }} :: {{ .User }}@{{ end }}{{ if .URL }}{{ .URL }}{{ end }}
 ```
 
 :::
@@ -54,3 +54,4 @@ import Config from "@site/src/components/Config.js";
 | `.Url`   | `string` | the URL of the state where pulumi stores resources |
 
 [templates]: /docs/configuration/templates
+[pulumi]: https://www.pulumi.com/

--- a/website/docs/segments/cloud/sitecore.mdx
+++ b/website/docs/segments/cloud/sitecore.mdx
@@ -39,7 +39,7 @@ Display current [Sitecore] environment. Will not be active when sitecore.json an
 
 :::
 
-## Options
+### Properties
 
 | Name           | Type     | Description                              |
 | -------------- | -------- | ---------------------------------------- |

--- a/website/docs/segments/health/nightscout.mdx
+++ b/website/docs/segments/health/nightscout.mdx
@@ -66,7 +66,7 @@ Or display in mmol/l (instead of the default mg/dl) with the following template:
 | -------------- | :-----------------: | :-----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `url`          |      `string`       |         | Your Nightscout URL, including the full path to entries.json AND count=1 AND token. Example above. You'll know this works if you can curl it yourself and get a single value |
 | `headers`      | `map[string]string` |         | A key, value map of Headers to send with the request                                                                                                                         |
-| `http_timeout` |        `int`        |  `500`  | in milliseconds - how long do you want to wait before you want to see your prompt more than your sugar? I figure a half second is a good default                             |
+| `http_timeout` |        `int`        |  `20`   | in milliseconds - how long do you want to wait before you want to see your prompt more than your sugar? I figure a half second is a good default                             |
 
 :::info
 You can change the icons for trend, put the trend elsewhere, add text, however you like!
@@ -89,26 +89,26 @@ Make sure your NerdFont has the glyph you want or [search for one][nf-search].
 :::note default template
 
 ```template
-{{ .Sgv }}
+ {{ .Sgv }}
 ```
 
 :::
 
 ### Properties
 
-| Name        | Type     | Description                                                                                                |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| .ID         | `string` | The internal ID of the object                                                                              |
-| .Sgv        | `int`    | Your Serum Glucose Value (your sugar)                                                                      |
-| .Date       | `int`    | The unix timestamp of the entry                                                                            |
-| .DateString | `time`   | The timestamp of the entry                                                                                 |
-| .Trend      | `int`    | The trend of the entry                                                                                     |
-| .Device     | `string` | The device linked to the entry                                                                             |
-| .Type       | `string` | The type of the entry                                                                                      |
-| .UtcOffset  | `int`    | The UTC offset                                                                                             |
-| .SysTime    | `time`   | The time on the system                                                                                     |
-| .Mills      | `int`    | The amount of mills                                                                                        |
-| .TrendIcon  | `string` | By default, this will be something like ↑↑ or ↘ etc but you can override them with any glyph as seen above |
+| Name          | Type     | Description                                                                                                |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
+| `.ID`         | `string` | The internal ID of the object                                                                              |
+| `.Sgv`        | `int`    | Your Serum Glucose Value (your sugar)                                                                      |
+| `.Date`       | `int`    | The unix timestamp of the entry                                                                            |
+| `.DateString` | `time`   | The timestamp of the entry                                                                                 |
+| `.Trend`      | `int`    | The trend of the entry                                                                                     |
+| `.Device`     | `string` | The device linked to the entry                                                                             |
+| `.Type`       | `string` | The type of the entry                                                                                      |
+| `.UtcOffset`  | `int`    | The UTC offset                                                                                             |
+| `.SysTime`    | `time`   | The time on the system                                                                                     |
+| `.Mills`      | `int`    | The amount of mills                                                                                        |
+| `.TrendIcon`  | `string` | By default, this will be something like ↑↑ or ↘ etc but you can override them with any glyph as seen above |
 
 [templates]: /docs/configuration/templates
 [nightscout]: http://www.nightscout.info/

--- a/website/docs/segments/health/strava.mdx
+++ b/website/docs/segments/health/strava.mdx
@@ -4,8 +4,6 @@ title: Strava
 sidebar_label: Strava
 ---
 
-import StravaConnect from "/img/strava_connect.svg";
-
 ## What
 
 [Strava][strava] is a popular activity tracker for bike, run or any other training.
@@ -20,9 +18,7 @@ This will give you an access and a refresh token. Paste the tokens into your Str
 
 Click the following link to connect with Strava:
 
-<a href="https://www.strava.com/oauth/authorize?client_id=76033&response_type=code&redirect_uri=https://ohmyposh.dev/api/auth&approval_prompt=force&scope=read,activity:read&state=strava">
-  <StravaConnect />
-</a>
+[![strava-connect](/img/strava_connect.svg)][strava-connect]
 
 ## Sample Configuration
 
@@ -65,7 +61,7 @@ import Config from "@site/src/components/Config.js";
 | `access_token`          | `string` |          | token from Strava login, see login link in section above.                                                     |
 | `refresh_token`         | `string` |          | token from Strava login, see login link in section above.                                                     |
 | `expires_in`            |  `int`   |   `0`    | the default timeout of the token from the Strava login                                                        |
-| `http_timeout`          |  `int`   |  `500`   | in milliseconds - how long do you want to wait before you want to see your prompt more than your strava data? |
+| `http_timeout`          |  `int`   |   `20`   | in milliseconds - how long do you want to wait before you want to see your prompt more than your strava data? |
 | `ride_icon`             | `string` | `\uf206` |                                                                                                               |
 | `run_icon`              | `string` | `\ue213` |                                                                                                               |
 | `skiing_icon`           | `string` | `\ue213` |                                                                                                               |
@@ -77,7 +73,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ if .Error }}{{ .Error }}{{ else }}{{ .Ago }}{{ end }}
+ {{ if .Error }}{{ .Error }}{{ else }}{{ .Ago }}{{ end }}
 ```
 
 :::
@@ -106,4 +102,4 @@ Now, go out and have a fun ride or run!
 
 [templates]: /docs/configuration/templates
 [strava]: http://www.strava.com/
-[strava-connect]: https://www.strava.com/oauth/authorize?client_id=76033&response_type=code&redirect_uri=https://ohmyposh.dev/api/auth&approval_prompt=force&scope=read,activity:read
+[strava-connect]: https://www.strava.com/oauth/authorize?client_id=76033&response_type=code&redirect_uri=https://ohmyposh.dev/api/auth&approval_prompt=force&scope=read,activity:read&state=strava

--- a/website/docs/segments/health/withings.mdx
+++ b/website/docs/segments/health/withings.mdx
@@ -18,11 +18,9 @@ This will give you an access and a refresh token. Paste the tokens into your Wit
 
 Click the following link to connect with Withings:
 
-<div className="withings">
-  <a href="https://account.withings.com/oauth2_user/authorize2?client_id=93675962e88ddfe53f83c0c900558f72174e0ac70ccfb57e48053530c7e6e494&response_type=code&redirect_uri=https://ohmyposh.dev/api/auth&scope=user.activity,user.metrics&state=withings">
-    <WithingsConnect className="withings" />
-  </a>
-</div>
+<a href="https://account.withings.com/oauth2_user/authorize2?client_id=93675962e88ddfe53f83c0c900558f72174e0ac70ccfb57e48053530c7e6e494&response_type=code&redirect_uri=https://ohmyposh.dev/api/auth&scope=user.activity,user.metrics&state=withings" className="withings">
+  <WithingsConnect />
+</a>
 
 ## Sample Configuration
 
@@ -51,7 +49,7 @@ import Config from "@site/src/components/Config.js";
 | `access_token`  | `string` |         | token from Withings login, see login link in section above.                                   |
 | `refresh_token` | `string` |         | token from Withings login, see login link in section above.                                   |
 | `expires_in`    |  `int`   |   `0`   | the default timeout of the token from the Withings login                                      |
-| `http_timeout`  |  `int`   |  `500`  | how long do you want to wait before you want to see your prompt more than your Withings data? |
+| `http_timeout`  |  `int`   |  `20`   | how long do you want to wait before you want to see your prompt more than your Withings data? |
 
 ## Template ([info][templates])
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -159,30 +159,30 @@ iframe.youtube {
   margin-top: 25px;
 }
 
-.withings {
-  width: 150px;
-}
-
-[data-theme="light"] .withings path {
-  fill: white;
-}
-
-[data-theme="dark"] .withings path {
-  fill: black;
-}
-
-[data-theme="dark"] div.withings {
+[data-theme="dark"] .withings {
   background: white;
   padding: 17px 10px 10px 10px;
   display: inline;
   border-radius: 10px;
 }
 
-[data-theme="light"] div.withings {
+[data-theme="light"] .withings {
   background: black;
   padding: 17px 10px 10px 10px;
   display: inline;
   border-radius: 10px;
+}
+
+.withings svg {
+  width: 150px;
+}
+
+[data-theme="light"] .withings svg path {
+  fill: white;
+}
+
+[data-theme="dark"] .withings svg path {
+  fill: black;
 }
 
 h1.hero__title {


### PR DESCRIPTION
## Summary by Sourcery

Update cloud and health segment documentation, styling, and Pulumi icon usage for consistency and clarity across code, tests, and docs.

Enhancements:
- Change the Pulumi segment default template and powerline symbol to use a new glyph and ensure the code, docs, and tests all reference it consistently.
- Refine Withings SVG styling and theming to better separate container styles from icon sizing and colors.

Documentation:
- Adjust Nightscout, Strava, and Withings segment docs to use shorter HTTP timeouts, tidy templates, and simplify OAuth connect links and references.
- Clarify cloud provider segment docs (AWS, Azure, GCP, Pulumi, Azure Dev CLI, Sitecore) with provider links, icon usage, and terminology tweaks.

Tests:
- Update Pulumi segment tests to expect the new icon glyph in all scenarios.