### PR TITLE
feat(git): remove unused `fetch_worktree_count` option

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -61,22 +61,26 @@ func (s *GitStatus) add(code string) {
 }
 
 const (
-	// DisableWithJJ disables the git segment when there's a .jj directory in the parent file path
-	DisableWithJJ options.Option = "disable_with_jj"
 	// FetchStatus fetches the status of the repository
 	FetchStatus options.Option = "fetch_status"
 	// FetchPushStatus fetches the push-remote status
 	FetchPushStatus options.Option = "fetch_push_status"
 	// IgnoreStatus allows to ignore certain repo's for status information
 	IgnoreStatus options.Option = "ignore_status"
-	// FetchWorktreeCount fetches the worktree count
-	FetchWorktreeCount options.Option = "fetch_worktree_count"
 	// FetchUpstreamIcon fetches the upstream icon
 	FetchUpstreamIcon options.Option = "fetch_upstream_icon"
 	// FetchBareInfo fetches the bare repo status
 	FetchBareInfo options.Option = "fetch_bare_info"
 	// FetchUser fetches the current user for the repo
 	FetchUser options.Option = "fetch_user"
+	// UntrackedModes list the optional untracked files mode per repo
+	UntrackedModes options.Option = "untracked_modes"
+	// IgnoreSubmodules list the optional ignore-submodules mode per repo
+	IgnoreSubmodules options.Option = "ignore_submodules"
+	// MappedBranches allows overriding certain branches with an icon/text
+	MappedBranches options.Option = "mapped_branches"
+	// DisableWithJJ disables the git segment when there's a .jj directory in the parent file path
+	DisableWithJJ options.Option = "disable_with_jj"
 
 	// BranchIcon the icon to use as branch indicator
 	BranchIcon options.Option = "branch_icon"
@@ -118,12 +122,6 @@ const (
 	GitlabIcon options.Option = "gitlab_icon"
 	// GitIcon shows when the upstream can't be identified
 	GitIcon options.Option = "git_icon"
-	// UntrackedModes list the optional untracked files mode per repo
-	UntrackedModes options.Option = "untracked_modes"
-	// IgnoreSubmodules list the optional ignore-submodules mode per repo
-	IgnoreSubmodules options.Option = "ignore_submodules"
-	// MappedBranches allows overriding certain branches with an icon/text
-	MappedBranches options.Option = "mapped_branches"
 
 	DETACHED     = "(detached)"
 	BRANCHPREFIX = "ref: refs/heads/"

--- a/themes/1_shell.omp.json
+++ b/themes/1_shell.omp.json
@@ -26,8 +26,7 @@
           "options": {
             "branch_icon": "\ue725 ",
             "fetch_status": true,
-            "fetch_upstream_icon": true,
-            "fetch_worktree_count": true
+            "fetch_upstream_icon": true
           },
           "style": "diamond",
           "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",

--- a/themes/clean-detailed.omp.json
+++ b/themes/clean-detailed.omp.json
@@ -63,8 +63,7 @@
           "options": {
             "branch_icon": "\ue725 ",
             "fetch_status": true,
-            "fetch_upstream_icon": true,
-            "fetch_worktree_count": true
+            "fetch_upstream_icon": true
           },
           "style": "diamond",
           "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",

--- a/themes/devious-diamonds.omp.yaml
+++ b/themes/devious-diamonds.omp.yaml
@@ -189,7 +189,6 @@ blocks:
           branch_icon: " "
           fetch_status: true
           fetch_upstream_icon: true
-          fetch_worktree_count: true
         template: "{{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }}  {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }}  {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} 󰆓 {{ .StashCount }}{{ end }}"
   - type: prompt
     alignment: left

--- a/themes/if_tea.omp.json
+++ b/themes/if_tea.omp.json
@@ -74,8 +74,7 @@
           "options": {
             "branch_icon": "\ue725 ",
             "fetch_status": true,
-            "fetch_upstream_icon": true,
-            "fetch_worktree_count": true
+            "fetch_upstream_icon": true
           },
           "style": "diamond",
           "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",

--- a/themes/kushal.omp.json
+++ b/themes/kushal.omp.json
@@ -94,8 +94,7 @@
           "options": {
             "branch_icon": "\ue725 ",
             "fetch_status": true,
-            "fetch_upstream_icon": true,
-            "fetch_worktree_count": true
+            "fetch_upstream_icon": true
           },
           "style": "powerline",
           "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }}<#CAEBE1> \uf046 {{ .Staging.String }}</>{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",

--- a/themes/markbull.omp.json
+++ b/themes/markbull.omp.json
@@ -60,7 +60,6 @@
             "commit_icon": "\uf417 ",
             "fetch_status": true,
             "fetch_upstream_icon": true,
-            "fetch_worktree_count": true,
             "git_icon": "\uf1d3 ",
             "github_icon": "\uf408 ",
             "gitlab_icon": "\uf296 ",

--- a/themes/night-owl.omp.json
+++ b/themes/night-owl.omp.json
@@ -53,7 +53,6 @@
             "branch_icon": "\ue725 ",
             "fetch_status": true,
             "fetch_upstream_icon": true,
-            "fetch_worktree_count": true,
             "mapped_branches": {
               "feat/*": "🚀 ",
               "bug/*": "🐛 "

--- a/themes/onehalf.minimal.omp.json
+++ b/themes/onehalf.minimal.omp.json
@@ -37,8 +37,7 @@
         {
           "options": {
             "branch_icon": "",
-            "fetch_status": true,
-            "fetch_worktree_count": true
+            "fetch_status": true
           },
           "style": "plain",
           "template": "<p:yellow>git</>:({{ if or (.Working.Changed) (.Staging.Changed) (gt .StashCount 0) }}<p:magenta>{{ .HEAD }}</>{{ else }}<p:green>{{ .HEAD }}</>{{ end }}{{ if (gt .Ahead 0)}}<p:cyan>{{ .BranchStatus }}</>{{ end }}{{ if (gt .Behind 0)}}<p:cyan>{{ .BranchStatus }}</>{{ end }}{{ if .Staging.Changed }} <p:green>{{ .Staging.String }}</>{{ end }}{{ if .Working.Changed }} <p:red>{{ .Working.String }}</>{{ end }})",

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1729,12 +1729,12 @@
                     "type": "boolean",
                     "title": "Display Status",
                     "description": "Display the local changes or not",
-                    "default": true
+                    "default": false
                   },
-                  "fetch_worktree_count": {
+                  "fetch_push_status": {
                     "type": "boolean",
-                    "title": "Display Worktree Count",
-                    "description": "Display the worktree count or not",
+                    "title": "Display Push Status",
+                    "description": "Display the push-remote ahead/behind information or not",
                     "default": false
                   },
                   "fetch_upstream_icon": {
@@ -1747,6 +1747,12 @@
                     "type": "boolean",
                     "title": "Fetch info when in a bare repo",
                     "description": "Fetch info when in a bare repo or not",
+                    "default": false
+                  },
+                  "fetch_user": {
+                    "type": "boolean",
+                    "title": "Fetch the user",
+                    "description": "Fetch the current configured user for the repository",
                     "default": false
                   },
                   "disable_with_jj": {
@@ -1869,6 +1875,12 @@
                     "description": "Icon/text to display when the upstream is not known/mapped",
                     "default": "\ue5fb"
                   },
+                  "upstream_icons": {
+                    "type": "object",
+                    "title": "Status string formats",
+                    "description": "a key, value map representing the remote URL (or a part of that URL) and icon to use in case the upstream URL contains the key. These get precedence over the standard icons",
+                    "default": {}
+                  },
                   "untracked_modes": {
                     "type": "object",
                     "title": "Untracked files mode",
@@ -1890,20 +1902,8 @@
                       "type": "string"
                     }
                   },
-                  "fetch_user": {
-                    "type": "boolean",
-                    "title": "Fetch the user",
-                    "description": "Fetch the current configured user for the repository",
-                    "default": false
-                  },
                   "status_formats": {
                     "$ref": "#/definitions/status_formats"
-                  },
-                  "upstream_icons": {
-                    "type": "object",
-                    "title": "Status string formats",
-                    "description": "a key, value map representing the remote URL (or a part of that URL) and icon to use in case the upstream URL contains the key. These get precedence over the standard icons",
-                    "default": {}
                   },
                   "mapped_branches": {
                     "$ref": "#/definitions/mapped_branches"
@@ -4039,7 +4039,7 @@
                     "type": "boolean",
                     "title": "Display Status",
                     "description": "Display the local changes or not",
-                    "default": true
+                    "default": false
                   },
                   "status_formats": {
                     "$ref": "#/definitions/status_formats"

--- a/themes/uew.omp.json
+++ b/themes/uew.omp.json
@@ -20,8 +20,7 @@
             "options": {
               "branch_icon": "\ue725 ",
               "fetch_status": true,
-              "fetch_upstream_icon": true,
-              "fetch_worktree_count": true
+              "fetch_upstream_icon": true
             },
             "style": "diamond",
             "template": "<#fff>{{ .UpstreamIcon }}</>{{ .HEAD }}",

--- a/themes/wholespace.omp.json
+++ b/themes/wholespace.omp.json
@@ -86,8 +86,7 @@
           "options": {
             "branch_icon": "\ue725 ",
             "fetch_status": true,
-            "fetch_upstream_icon": true,
-            "fetch_worktree_count": true
+            "fetch_upstream_icon": true
           },
           "style": "diamond",
           "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",

--- a/website/docs/segments/scm/fossil.mdx
+++ b/website/docs/segments/scm/fossil.mdx
@@ -6,7 +6,7 @@ sidebar_label: Fossil
 
 ## What
 
-Display [fossil][fossil] information when in a fossil repository.
+Display [Fossil][fossil] information when in a fossil repository.
 
 ## Sample Configuration
 

--- a/website/docs/segments/scm/git.mdx
+++ b/website/docs/segments/scm/git.mdx
@@ -6,7 +6,7 @@ sidebar_label: Git
 
 ## What
 
-Display git information when in a git repository. Also works for subfolders. For maximum compatibility,
+Display git information when in a [Git][git] repository. Also works for subfolders. For maximum compatibility,
 make sure your `git` executable is up-to-date (when branch or status information is incorrect for example).
 
 ## Sample Configuration
@@ -57,10 +57,10 @@ You can set the following options to `true` to enable fetching additional inform
 | `ignore_status`       |     `[]string`      |         | do not fetch status for these repo's. Uses the repo's root folder and same logic as the [exclude_folders][exclude_folders] property                                                                                                                                                                                                   |
 | `fetch_upstream_icon` |      `boolean`      | `false` | fetch upstream icon                                                                                                                                                                                                                                                                                                                   |
 | `fetch_bare_info`     |      `boolean`      | `false` | fetch bare repo info                                                                                                                                                                                                                                                                                                                  |
+| `fetch_user`          |   [`User`](#user)   | `false` | fetch the current configured user for the repository                                                                                                                                                                                                                                                                                  |
 | `untracked_modes`     | `map[string]string` |         | map of repo's where to override the default [untracked files mode][untracked]:<ul><li>`no`</li><li>`normal`</li><li>`all`</li></ul>For example `"untracked_modes": { "/Users/me/repos/repo1": "no" }` - defaults to `normal` for all repo's. If you want to override for all repo's, use `*` to set the mode instead of the repo path |
 | `ignore_submodules`   | `map[string]string` |         | map of repo's where to change the [--ignore-submodules][submodules] flag (`none`, `untracked`, `dirty` or `all`). For example `"ignore_submodules": { "/Users/me/repos/repo1": "all" }`. If you want to override for all repo's, use `*` to set the mode instead of the repo path                                                     |
 | `native_fallback`     |      `boolean`      | `false` | when set to `true` and `git.exe` is not available when inside a WSL2 shared Windows drive, we will fallback to the native `git` executable to fetch data. Not all information can be displayed in this case                                                                                                                           |
-| `fetch_user`          |   [`User`](#user)   | `false` | fetch the current configured user for the repository                                                                                                                                                                                                                                                                                  |
 | `status_formats`      | `map[string]string` |         | a key, value map allowing to override how individual status items are displayed. For example, `"status_formats": { "Added": "Added: %d" }` will display the added count as `Added: 1` instead of `+1`. See the [Status](#status) section for available overrides.                                                                     |
 | `source`              |      `string`       |  `cli`  | <ul><li>`cli`: fetch the information using the git CLI</li><li>`pwsh`: fetch the information from the [posh-git][poshgit] PowerShell Module</li></ul>                                                                                                                                                                                 |
 | `mapped_branches`     |      `object`       |         | custom glyph/text for specific branches. You can use `*` at the end as a wildcard character for matching                                                                                                                                                                                                                              |
@@ -232,6 +232,7 @@ You can then use the `POSH_GIT_STRING` environment variable in a [text segment][
   }}
 />
 
+[git]: https://git-scm.com/
 [poshgit]: https://github.com/dahlbyk/posh-git
 [templates]: /docs/configuration/templates
 [hyperlinks]: /docs/configuration/templates#custom

--- a/website/docs/segments/scm/plastic.mdx
+++ b/website/docs/segments/scm/plastic.mdx
@@ -6,7 +6,7 @@ sidebar_label: Plastic SCM
 
 ## What
 
-Display Plastic SCM information when in a plastic repository. Also works for subfolders.
+Display [Plastic SCM][plastic-scm] information when in a plastic repository. Also works for subfolders.
 For maximum compatibility, make sure your `cm` executable is up-to-date
 (when branch or status information is incorrect for example).
 
@@ -48,10 +48,11 @@ by leaving a like!
 As doing multiple `cm` calls can slow down the prompt experience, we do not fetch information by default.
 You can set the following property to `true` to enable fetching additional information (and populate the template).
 
-| Name             |        Type         | Default | Description                                                                                                                                                                                                                                                      |
-| ---------------- | :-----------------: | :-----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `fetch_status`   |      `boolean`      | `false` | fetch the local changes                                                                                                                                                                                                                                          |
-| `status_formats` | `map[string]string` |         | a key, value map allowing to override how individual status items are displayed. For example, `"status_formats": { "Added": "Added: %d" }` will display the added count as `Added: 1` instead of `+1`. See the [Status](#status) section for available overrides |
+| Name              |        Type         | Default | Description                                                                                                                                                                                                                                                      |
+| ----------------- | :-----------------: | :-----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fetch_status`    |      `boolean`      | `false` | fetch the local changes                                                                                                                                                                                                                                          |
+| `native_fallback` |      `boolean`      | `false` | when set to `true` and `cm.exe` is not available when inside a WSL2 shared Windows drive, we will fallback to the native `cm` executable to fetch data. Not all information can be displayed in this case                                                        |
+| `status_formats`  | `map[string]string` |         | a key, value map allowing to override how individual status items are displayed. For example, `"status_formats": { "Added": "Added: %d" }` will display the added count as `Added: 1` instead of `+1`. See the [Status](#status) section for available overrides |
 
 ### Icons
 
@@ -75,7 +76,7 @@ You can set the following property to `true` to enable fetching additional infor
 :::note default template
 
 ```template
-{{ .Selector }}
+ {{ .Selector }}
 ```
 
 :::
@@ -112,4 +113,5 @@ Local changes use the following syntax:
 | `v`  | Moved       |
 
 [templates]: /docs/configuration/templates
+[plastic-scm]: https://www.plasticscm.com/
 [fa-issue]: https://github.com/FortAwesome/Font-Awesome/issues/18504

--- a/website/docs/segments/scm/sapling.mdx
+++ b/website/docs/segments/scm/sapling.mdx
@@ -6,7 +6,7 @@ sidebar_label: Sapling
 
 ## What
 
-Display [sapling][sapling] information when in a sapling repository.
+Display [Sapling][sapling] information when in a sapling repository.
 
 ## Sample Configuration
 
@@ -41,7 +41,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ if .Bookmark }}\uf097 {{ .Bookmark }}*{{ else }}\ue729 {{ .ShortHash }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}
+ {{ if .Bookmark }}\uf097 {{ .Bookmark }}*{{ else }}\ue729 {{ .ShortHash }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}
 ```
 
 :::

--- a/website/docs/segments/scm/svn.mdx
+++ b/website/docs/segments/scm/svn.mdx
@@ -6,7 +6,7 @@ sidebar_label: Subversion
 
 ## What
 
-Display subversion information when in a subversion repository. Also works for subfolders. For maximum compatibility,
+Display [Subversion][svn] information when in a subversion repository. Also works for subfolders. For maximum compatibility,
 make sure your `svn` executable is up-to-date (when branch or status information is incorrect for example).
 
 ## Sample Configuration


### PR DESCRIPTION
## Summary by Sourcery

Remove the deprecated Git `fetch_worktree_count` option from code, themes, and schema, and tidy up SCM documentation.

New Features:
- Document the `native_fallback` option for Plastic SCM and Git segments and add cross-links to official SCM tool sites.

Enhancements:
- Reorganize and clarify Git segment configuration options, including moving `fetch_user` and related options into a more appropriate section.
- Standardize wording and capitalization in SCM documentation and adjust example templates for consistency.

Documentation:
- Improve SCM segment docs with clearer descriptions, external reference links, and updated configuration tables.

Chores:
- Clean up themes and configuration schema to stop referencing the removed `fetch_worktree_count` Git option.