### PR TITLE
fix(markdown): use ``markdownlint-cli2.yaml`` configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -12,7 +12,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -12,7 +12,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -12,7 +12,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/feat.yml
+++ b/.github/ISSUE_TEMPLATE/feat.yml
@@ -12,7 +12,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-<!--  markdownlint-disable MD041 -->
 ### Prerequisites
 
 - [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].

--- a/.github/agents/segment-docs.md
+++ b/.github/agents/segment-docs.md
@@ -1,0 +1,223 @@
+---
+name: Segment Documentation
+description: Agent specializing in generating and updating Oh My Posh segment documentation. Analyzes Go segment code to create or update documentation with proper Options, Template properties, and Sample Configuration sections.
+---
+
+You are a documentation specialist for Oh My Posh segments. Your scope is limited to:
+
+1. Analyzing segment Go source files in `src/segments/`
+2. Creating or updating segment documentation in `website/docs/segments/<category>/`
+3. Ensuring consistency between code and documentation
+
+## Key Concepts
+
+### Segment Structure
+
+Each segment has two main files:
+
+1. **Source code**: `src/segments/<segment>.go` - Contains the implementation
+2. **Documentation**: `website/docs/segments/<category>/<segment>.mdx` - Contains user documentation
+
+### Documentation Categories
+
+Segments are organized in these categories under `website/docs/segments/`:
+
+- `cli/` - Command-line tools
+- `cloud/` - Cloud providers (AWS, Azure, GCP, etc.)
+- `health/` - Health and monitoring
+- `languages/` - Programming language version displays
+- `music/` - Music players
+- `scm/` - Source control (Git, Mercurial, etc.)
+- `system/` - System information (battery, time, etc.)
+- `web/` - Web services and APIs
+
+## Analysis Process
+
+When analyzing a segment, extract:
+
+### 1. Options (Configuration)
+
+Options are defined as `options.Option` constants in the Go file. Look for patterns like:
+
+```go
+const (
+    FetchStatus    options.Option = "fetch_status"
+    FetchUser      options.Option = "fetch_user"
+    BranchIcon     options.Option = "branch_icon"
+)
+```
+
+For each option, determine:
+
+- **Name**: The string value (e.g., `fetch_status`)
+- **Type**: Inferred from usage (`Bool()` → boolean, `String()` → string, `StringArray()` → []string, `KeyValueMap()` → map[string]string, `Int()` → int, `Float64()` → float64)
+- **Default**: Found in the second argument of getter calls like `props.Bool(FetchStatus, false)`
+- **Description**: From comment above the constant or inferred from usage context
+
+### 2. Template
+
+The default template is defined in the `Template()` method:
+
+```go
+func (g *Git) Template() string {
+    return " {{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }} "
+}
+```
+
+### 3. Properties (Template Variables)
+
+Properties are fields on the segment struct that can be used in templates. Look for:
+
+- Public fields (capitalized) on the main struct
+- Nested structs with public fields (e.g., `.Working.Changed`)
+- Methods that return values (e.g., `StashCount()`, `Commit()`)
+
+Document each property with:
+
+- **Name**: The field name with dot notation (e.g., `.HEAD`, `.Working.Changed`)
+- **Type**: The Go type (string, int, boolean, custom struct)
+- **Description**: What the property represents
+
+## Documentation Format
+
+### Standard MDX Structure
+
+```mdx
+---
+id: segment-name
+title: Segment Title
+sidebar_label: Segment Title
+---
+
+## What
+
+Brief description of what the segment displays and when.
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "segment-name",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#foreground-color",
+    background: "#background-color",
+    template: "{{ .PropertyName }}",
+    options: {
+      option_name: value,
+    },
+  }}
+/>
+
+## Options
+
+| Name | Type | Default | Description |
+| ---- | :--: | :-----: | ----------- |
+| `option_name` | `type` | `default` | Description of the option |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+{{ default template from Template() method }}
+```
+
+:::
+
+### Properties
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `.PropertyName` | `type` | Description |
+
+[templates]: /docs/configuration/templates
+```
+
+## Key Mapping Rules
+
+### Option Type Detection
+
+Detect types from how options are retrieved in code:
+
+| Go Method | Documentation Type |
+| --------- | ------------------ |
+| `options.Bool(option, default)` | `boolean` |
+| `options.String(option, default)` | `string` |
+| `options.StringArray(option, default)` | `[]string` |
+| `options.Int(option, default)` | `int` |
+| `options.Float64(option, default)` | `float64` |
+| `options.KeyValueMap(option, default)` | `map[string]string` |
+| `options.Color(option, default)` | `string` (color) |
+
+### Common Options
+
+Some options are defined in `src/segments/options/map.go` and shared across segments:
+
+- `fetch_version` - Whether to fetch version information
+- `display_default` - Whether to display default values
+- `cache_duration` - Cache duration for fetched data
+- `http_timeout` - HTTP request timeout
+
+### Nested Structs
+
+For nested types like `Status`, `Commit`, `User`, create subsections:
+
+```mdx
+#### Status
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `.Modified` | `int` | Number of modified files |
+| `.Changed` | `boolean` | Whether there are changes |
+```
+
+## Workflow
+
+### Creating New Documentation
+
+1. Read the segment source file completely
+2. Extract all `options.Option` constants and their usage
+3. Find the `Template()` method for default template
+4. Identify all public fields and methods on the struct
+5. **Ask** the user the appropriate category for the segment if not provided
+6. Generate documentation following the standard format
+
+### Updating Existing Documentation
+
+1. Compare current documentation with source code
+2. Identify missing or outdated options
+3. Identify missing or outdated template properties
+4. Update tables while preserving existing descriptions where accurate
+5. Ensure sample configuration includes new options
+
+**Important**: Some properties exist in base structs (like `ScmStatus` in `scm.go`) but may not
+be used by specific segments. Only document properties that are actually populated/used by the
+segment's code. Check the segment's `Enabled()` method and status-setting functions to verify
+which fields are actually set.
+
+## Validation Checklist
+
+Before completing documentation:
+
+- [ ] All `options.Option` constants from code are documented
+- [ ] Option types match actual usage in code
+- [ ] Default values match code defaults
+- [ ] All public struct fields are documented as properties
+- [ ] Template in documentation matches `Template()` method
+- [ ] Sample configuration is valid and demonstrates key features
+- [ ] All referenced links exist (templates, related segments)
+- [ ] Markdown follows `.github/instructions/markdown.md` guidelines
+
+## File References
+
+When working on segment documentation, consult these files:
+
+- `.github/instructions/segment.md` - Segment scaffolding instructions
+- `.github/instructions/markdown.md` - Markdown formatting rules
+- `src/segments/options/map.go` - Shared option definitions
+- `src/segments/base.go` - Base segment structure
+- `src/segments/scm.go` - SCM-specific base (for git, mercurial, etc.)
+- `src/segments/language.go` - Language segment base (for Python, Node, etc.)

--- a/.github/prompts/segment.prompt.md
+++ b/.github/prompts/segment.prompt.md
@@ -2,7 +2,7 @@
 description: 'Generate a new Oh My Posh segment (code, registration, docs, schema, sidebar)'
 agent: 'agent'
 model: 'Claude Sonnet 4'
-tools: ['web/githubRepo', 'search/codebase', 'edit/createFile', 'edit/editFiles', 'read/problems', 'execute/getTerminalOutput', 'execute/runInTerminal', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/createAndRunTask', 'execute/runTask', 'read/getTaskOutput', 'execute/runTests', 'search', 'execute/testFailure', 'search/usages']
+tools: ['execute/testFailure', 'execute/getTerminalOutput', 'execute/runTask', 'execute/createAndRunTask', 'execute/runInTerminal', 'execute/runTests', 'read/problems', 'read/readFile', 'read/terminalSelection', 'read/terminalLastCommand', 'read/getTaskOutput', 'edit/createFile', 'edit/editFiles', 'search', 'web/githubRepo', 'agent']
 ---
 
 # New Segment Prompt
@@ -32,3 +32,10 @@ Execute
   - `.instructions/segment.md`
   - Pass the collected inputs (`goTypeName`, `id/slug`, `category`, `title`,
     `description`, `properties`, `template`).
+
+Documentation
+
+- Use the `runSubagent` tool with `agentName: "Segment Documentation"` to delegate
+  documentation creation and updates.
+- Pass the segment details (name, category, title, description, properties, template)
+  in the prompt parameter for the subagent to generate or update the MDX documentation file.

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -15,5 +15,5 @@ jobs:
     - name: Lint files
       uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101
       with:
-          config: .markdownlint.yaml
+          config: .markdownlint-cli2.yaml
           globs: '**/*.md'

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,11 @@
+config:
+  MD013:
+    line_length: 120
+    code_blocks: false
+  MD024: false
+fix: true
+gitignore: true
+ignores:
+  - node_modules/
+  - .github/agents/segment-docs.md
+  - .github/PULL_REQUEST_TEMPLATE.md

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,6 +1,0 @@
-MD014: false
-MD024: false
-MD038: false
-line-length:
-  line_length: 120
-  code_blocks: false

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,2 @@
 node_modules/
+.github\agents\segment-docs.md

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,0 @@
-node_modules/
-.github\agents\segment-docs.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,14 +25,5 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.markdownlint": "explicit"
     }
-  },
-  "markdownlint.lintWorkspaceGlobs": [
-    "**/*.{md,mkd,mdwn,mdown,markdown,markdn,mdtxt,mdtext,workbook}",
-    "!**/*.code-search",
-    "!**/bower_components",
-    "!**/node_modules",
-    "!**/.git",
-    "!**/vendor",
-    "!**/AGENTS.md"
-  ]
+  }
 }

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -48,6 +48,11 @@ on getting started, have a look at the docs at https://ohmyposh.dev`,
 		_ = cmd.Help()
 	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		configEnv := os.Getenv("POSH_CONFIG")
+		if configEnv != "" && configFlag == "" {
+			configFlag = configEnv
+		}
+
 		traceEnv := os.Getenv("POSH_TRACE")
 		if traceEnv == "" && !trace {
 			return

--- a/src/runtime/cmd/run_test.go
+++ b/src/runtime/cmd/run_test.go
@@ -1,0 +1,13 @@
+package cmd
+
+import (
+	"testing"
+
+	runjobs "github.com/jandedobbeleer/oh-my-posh/src/runtime/jobs"
+)
+
+func TestCurrentGID(t *testing.T) {
+	if gid := runjobs.CurrentGID(); gid == 0 {
+		t.Fatalf("CurrentGID returned 0")
+	}
+}

--- a/src/runtime/jobs/jobs_common.go
+++ b/src/runtime/jobs/jobs_common.go
@@ -1,0 +1,25 @@
+package jobs
+
+import (
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// CurrentGID returns the current goroutine's id. We expose this here so
+// callers can register PIDs without parsing runtime.Stack in multiple
+// places.
+func CurrentGID() uint64 {
+	buf := make([]byte, 64)
+	n := runtime.Stack(buf, false)
+	s := strings.Fields(strings.TrimPrefix(string(buf[:n]), "goroutine "))
+	if len(s) == 0 {
+		return 0
+	}
+	idStr := s[0]
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}

--- a/src/runtime/jobs/jobs_other.go
+++ b/src/runtime/jobs/jobs_other.go
@@ -1,0 +1,82 @@
+//go:build !windows
+
+package jobs
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+var (
+	processesMu sync.Mutex
+	processes   = map[uint64]map[int]struct{}{}
+)
+
+func CreateJobForGoroutine() error        { return nil }
+func AssignPidToGoroutineJob(_ int) error { return nil }
+
+// setProcessGroup ensures the child process runs in its own process group so
+// it can be killed with a group kill (negative pid).
+func SetProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// registerProcessWithGID keeps track of a started child process for the
+// given goroutine id.
+func RegisterProcess(pid int) {
+	gid := CurrentGID()
+	processesMu.Lock()
+	m := processes[gid]
+	if m == nil {
+		m = map[int]struct{}{}
+		processes[gid] = m
+	}
+	m[pid] = struct{}{}
+	processesMu.Unlock()
+}
+
+func UnregisterProcess(pid int) {
+	gid := CurrentGID()
+	processesMu.Lock()
+	if m, ok := processes[gid]; ok {
+		delete(m, pid)
+		if len(m) == 0 {
+			delete(processes, gid)
+		}
+	}
+	processesMu.Unlock()
+}
+
+// KillGoroutineChildren attempts to kill all child processes started by the
+// goroutine identified by gid using process groups (PGID). This mirrors the
+// previous behavior performed in runtime/cmd.
+func KillGoroutineChildren(gid uint64) error {
+	processesMu.Lock()
+	pidsMap, ok := processes[gid]
+	if !ok || len(pidsMap) == 0 {
+		processesMu.Unlock()
+		return nil
+	}
+	pids := make([]int, 0, len(pidsMap))
+	for pid := range pidsMap {
+		pids = append(pids, pid)
+	}
+	delete(processes, gid)
+	processesMu.Unlock()
+
+	var errs []string
+	for _, pid := range pids {
+		// negative pid kills the process group
+		if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil {
+			errs = append(errs, fmt.Sprintf("kill -%d: %v", pid, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to kill child processes: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/src/runtime/jobs/jobs_windows.go
+++ b/src/runtime/jobs/jobs_windows.go
@@ -1,0 +1,171 @@
+//go:build windows
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/log"
+	"golang.org/x/sys/windows"
+)
+
+var (
+	jobsMu      sync.Mutex
+	jobs        = map[uint64]windows.Handle{}
+	processesMu sync.Mutex
+	processes   = map[uint64]map[int]struct{}{}
+)
+
+func init() {
+	// nothing to do here; runtime/cmd will call RegisterProcess when a
+	// child is started. We previously used AssignPidHandler to bridge this
+	// but now the jobs package exposes RegisterProcess directly.
+}
+
+// CreateJobForGoroutine creates a Job object for gid and sets the
+// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE flag so closing/terminating the job
+// kills all assigned processes.
+func CreateJobForGoroutine() error {
+	gid := CurrentGID()
+	jobsMu.Lock()
+	if _, ok := jobs[gid]; ok {
+		jobsMu.Unlock()
+		return nil
+	}
+	jobsMu.Unlock()
+
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return err
+	}
+
+	var info windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+
+	size := uint32(unsafe.Sizeof(info))
+	if _, err := windows.SetInformationJobObject(job, windows.JobObjectExtendedLimitInformation, uintptr(unsafe.Pointer(&info)), size); err != nil {
+		_ = windows.CloseHandle(job)
+	}
+
+	jobsMu.Lock()
+	jobs[gid] = job
+	jobsMu.Unlock()
+
+	return nil
+}
+
+// registerProcessWithGID keeps track of a started child process for the
+// given goroutine id and attempts to assign it to the Job object if present.
+func RegisterProcess(pid int) {
+	gid := CurrentGID()
+	processesMu.Lock()
+	m := processes[gid]
+	if m == nil {
+		m = map[int]struct{}{}
+		processes[gid] = m
+	}
+
+	m[pid] = struct{}{}
+	processesMu.Unlock()
+
+	// Try to assign to job if exists (best-effort)
+	jobsMu.Lock()
+	job, ok := jobs[gid]
+	jobsMu.Unlock()
+	if !ok {
+		log.Debugf("no job found for goroutine %d when assigning pid %d", gid, pid)
+		return
+	}
+
+	proc, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(pid))
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	defer func() {
+		err = windows.CloseHandle(proc)
+		if err != nil {
+			log.Error(err)
+		}
+	}()
+
+	if err = windows.AssignProcessToJobObject(job, proc); err != nil {
+		log.Error(err)
+	}
+}
+
+func UnregisterProcess(pid int) {
+	gid := CurrentGID()
+	processesMu.Lock()
+
+	if m, ok := processes[gid]; ok {
+		delete(m, pid)
+		if len(m) == 0 {
+			delete(processes, gid)
+		}
+	}
+
+	processesMu.Unlock()
+}
+
+// KillGoroutineChildren will first try to terminate a Job if present, and
+// otherwise will fall back to taskkill for each recorded pid.
+func KillGoroutineChildren(gid uint64) error {
+	// if Job exists, prefer terminating the Job
+	jobsMu.Lock()
+	job, hasJob := jobs[gid]
+	if hasJob {
+		delete(jobs, gid)
+	}
+	jobsMu.Unlock()
+	if hasJob {
+		// Terminate the job which kills all processes in it
+		if err := windows.TerminateJobObject(job, 1); err == nil {
+			// cleanup recorded pids as well
+			processesMu.Lock()
+			delete(processes, gid)
+			processesMu.Unlock()
+			return nil
+		}
+	}
+
+	// No job or terminate failed; fall back to per-pid taskkill
+	processesMu.Lock()
+	pidsMap, ok := processes[gid]
+	if !ok || len(pidsMap) == 0 {
+		processesMu.Unlock()
+		return nil
+	}
+	pids := make([]int, 0, len(pidsMap))
+	for pid := range pidsMap {
+		pids = append(pids, pid)
+	}
+	delete(processes, gid)
+	processesMu.Unlock()
+
+	var errs []string
+	for _, pid := range pids {
+		if err := exec.CommandContext(context.Background(), "taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run(); err != nil {
+			errs = append(errs, fmt.Sprintf("taskkill %d: %v", pid, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to kill child processes: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// setProcessGroup ensures the child process runs in its own process group
+// (CREATE_NEW_PROCESS_GROUP) so it can be terminated as a group.
+func SetProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}

--- a/src/segments/winget.go
+++ b/src/segments/winget.go
@@ -74,10 +74,11 @@ func (w *WinGet) parseWinGetOutput(output string) []WinGetPackage {
 	}
 
 	// Determine column positions from header (calculated once)
-	idIndex := strings.Index(headerLine, "Id")
-	versionIndex := strings.Index(headerLine, "Version")
-	availableIndex := strings.Index(headerLine, "Available")
-	sourceIndex := strings.Index(headerLine, "Source")
+	nameIndex := strings.Index(headerLine, "Name")
+	idIndex := strings.Index(headerLine, "Id") - nameIndex
+	versionIndex := strings.Index(headerLine, "Version") - nameIndex
+	availableIndex := strings.Index(headerLine, "Available") - nameIndex
+	sourceIndex := strings.Index(headerLine, "Source") - nameIndex
 
 	// If we can't find column positions, return empty
 	if idIndex < 0 || versionIndex < 0 || availableIndex < 0 {

--- a/src/segments/winget_test.go
+++ b/src/segments/winget_test.go
@@ -151,6 +151,20 @@ Python 3.11        Python.Python.3.11          3.11.0    3.11.5    winget
 				Available: "3.11.5",
 			},
 		},
+		{
+			Case: "Output with extra characters before header line",
+			Output: `<THESE ARE SOME EXTRA CHARACTERS>Name               Id                          Version   Available Source
+-----------------------------------------------------------------------------------
+Python 3.11        Python.Python.3.11          3.11.0    3.11.5    winget
+2 upgrades available.`,
+			ExpectedCount: 1,
+			ExpectedFirst: WinGetPackage{
+				Name:      "Python 3.11",
+				ID:        "Python.Python.3.11",
+				Current:   "3.11.0",
+				Available: "3.11.5",
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/themes/atomic.omp.json
+++ b/themes/atomic.omp.json
@@ -59,7 +59,7 @@
             "threshold": 0
           },
           "style": "diamond",
-          "template": " \ueba2 {{ .FormattedMs }}\u2800",
+          "template": " \ueba2 {{ .FormattedMs }} ",
           "trailing_diamond": "\ue0b4",
           "type": "executiontime"
         }

--- a/themes/cloud-context.omp.json
+++ b/themes/cloud-context.omp.json
@@ -83,7 +83,7 @@
           "foreground": "p:cloud-text-gcp",
           "style": "powerline",
           "powerline_symbol": "\ue0b4",
-          "template": " <p:symbol-color>\ue7b2</> {{ .Project }}",
+          "template": " <p:symbol-color>\udb84\uddf6</> {{ .Project }}",
           "type": "gcp"
         },
         {

--- a/website/README.md
+++ b/website/README.md
@@ -5,13 +5,13 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 ## Installation
 
 ```shell
-$ npm install
+npm install
 ```
 
 ## Local Development
 
 ```shell
-$ npm run start
+npm run start
 ```
 
 This command starts a local development server and open up a browser window.

--- a/website/docs/segments/scm/git.mdx
+++ b/website/docs/segments/scm/git.mdx
@@ -116,36 +116,41 @@ You can set the following options to `true` to enable fetching additional inform
 
 ### Properties
 
-| Name             | Type      | Description                                                                                                                      |
-| ---------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `.RepoName`      | `string`  | the repo folder name                                                                                                             |
-| `.Working`       | `Status`  | changes in the worktree (see below)                                                                                              |
-| `.Staging`       | `Status`  | staged changes in the work tree (see below)                                                                                      |
-| `.HEAD`          | `string`  | the current HEAD context (branch/rebase/merge/...)                                                                               |
-| `.Ref`           | `string`  | the current HEAD reference (branch/tag/...)                                                                                      |
-| `.Behind`        | `int`     | commits behind of upstream                                                                                                       |
-| `.Ahead`         | `int`     | commits ahead of upstream                                                                                                        |
-| `.PushBehind`    | `int`     | commits behind of push remote                                                                                                    |
-| `.PushAhead`     | `int`     | commits ahead of push remote                                                                                                     |
-| `.BranchStatus`  | `string`  | the current branch context (ahead/behind string representation)                                                                  |
-| `.Upstream`      | `string`  | the upstream name (remote)                                                                                                       |
-| `.UpstreamGone`  | `boolean` | whether the upstream is gone (no remote)                                                                                         |
-| `.UpstreamIcon`  | `string`  | the upst ream icon (based on the icons above)                                                                                    |
-| `.UpstreamURL`   | `string`  | the upstream URL for use in [hyperlinks][hyperlinks] in templates: `{{ url .UpstreamIcon .UpstreamURL }}`                        |
-| `.StashCount`    | `int`     | the stash count                                                                                                                  |
-| `.WorktreeCount` | `int`     | the worktree count                                                                                                               |
-| `.IsWorkTree`    | `boolean` | if in a worktree repo or not                                                                                                     |
-| `.IsBare`        | `boolean` | if in a bare repo or not, only set when `fetch_bare_info` is set to `true`                                                       |
-| `.Dir`           | `string`  | the repository's root directory                                                                                                  |
-| `.RelativeDir`   | `string`  | the current directory relative to the root directory                                                                             |
-| `.Kraken`        | `string`  | a link to the current HEAD in [GitKraken][kraken-ref] for use in [hyperlinks][hyperlinks] in templates `{{ url .HEAD .Kraken }}` |
-| `.Commit`        | `Commit`  | HEAD commit information (see below)                                                                                              |
-| `.Detached`      | `boolean` | true when the head is detached                                                                                                   |
-| `.Merge`         | `boolean` | true when in a merge                                                                                                             |
-| `.Rebase`        | `Rebase`  | contains the relevant information when in a rebase                                                                               |
-| `.CherryPick`    | `boolean` | true when in a cherry pick                                                                                                       |
-| `.Revert`        | `boolean` | true when in a revert                                                                                                            |
-| `.LatestTag`     | `string`  | the latest tag name                                                                                                              |
+| Name              | Type                | Description                                                                                                                      |
+| ----------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `.RepoName`       | `string`            | the repo folder name                                                                                                             |
+| `.Working`        | `Status`            | changes in the worktree (see below)                                                                                              |
+| `.Staging`        | `Status`            | staged changes in the work tree (see below)                                                                                      |
+| `.HEAD`           | `string`            | the current HEAD context (branch/rebase/merge/...)                                                                               |
+| `.Ref`            | `string`            | the current HEAD reference (branch/tag/...)                                                                                      |
+| `.Behind`         | `int`               | commits behind of upstream                                                                                                       |
+| `.Ahead`          | `int`               | commits ahead of upstream                                                                                                        |
+| `.PushBehind`     | `int`               | commits behind of push remote                                                                                                    |
+| `.PushAhead`      | `int`               | commits ahead of push remote                                                                                                     |
+| `.BranchStatus`   | `string`            | the current branch context (ahead/behind string representation)                                                                  |
+| `.Upstream`       | `string`            | the upstream name (remote)                                                                                                       |
+| `.UpstreamGone`   | `boolean`           | whether the upstream is gone (no remote)                                                                                         |
+| `.UpstreamIcon`   | `string`            | the upstream icon (based on the icons above)                                                                                     |
+| `.UpstreamURL`    | `string`            | the upstream URL for use in [hyperlinks][hyperlinks] in templates: `{{ url .UpstreamIcon .UpstreamURL }}`                        |
+| `.RawUpstreamURL` | `string`            | the raw upstream URL (not cleaned up for display)                                                                                |
+| `.Hash`           | `string`            | the full commit hash                                                                                                             |
+| `.ShortHash`      | `string`            | the short commit hash (7 characters)                                                                                             |
+| `.StashCount`     | `int`               | the stash count                                                                                                                  |
+| `.WorktreeCount`  | `int`               | the worktree count                                                                                                               |
+| `.IsWorkTree`     | `boolean`           | if in a worktree repo or not                                                                                                     |
+| `.IsBare`         | `boolean`           | if in a bare repo or not, only set when `fetch_bare_info` is set to `true`                                                       |
+| `.Dir`            | `string`            | the repository's root directory                                                                                                  |
+| `.RelativeDir`    | `string`            | the current directory relative to the root directory                                                                             |
+| `.Kraken`         | `string`            | a link to the current HEAD in [GitKraken][kraken-ref] for use in [hyperlinks][hyperlinks] in templates `{{ url .HEAD .Kraken }}` |
+| `.Commit`         | `Commit`            | HEAD commit information (see below)                                                                                              |
+| `.Detached`       | `boolean`           | true when the head is detached                                                                                                   |
+| `.Merge`          | `boolean`           | true when in a merge                                                                                                             |
+| `.Rebase`         | `Rebase`            | contains the relevant information when in a rebase                                                                               |
+| `.CherryPick`     | `boolean`           | true when in a cherry pick                                                                                                       |
+| `.Revert`         | `boolean`           | true when in a revert                                                                                                            |
+| `.User`           | `User`              | the current configured user (requires `fetch_user` to be enabled)                                                                |
+| `.Remotes`        | `map[string]string` | a map of remote names to their URLs                                                                                              |
+| `.LatestTag`      | `string`            | the latest tag name                                                                                                              |
 
 #### Status
 


### PR DESCRIPTION
## Summary by Sourcery

Improve process management for timed segments, enhance winget output parsing, add documentation tooling for segment docs, and align markdown and issue templates with current project conventions.

Bug Fixes:
- Fix winget segment parsing to correctly handle extra text before the header and align column offsets from the Name column.
- Ensure POSH_CONFIG environment variable is respected as a default for the CLI config flag.
- Correct Code of Conduct links in GitHub issue templates to point to CODE_OF_CONDUCT.md.
- Update git segment documentation to include new upstream, hash, user, and remotes properties.

Enhancements:
- Add per-goroutine job and process tracking to allow timed segments to terminate child processes on timeout while caching segment data when enabled.
- Refine command execution helper to run processes in dedicated groups, track PIDs by goroutine, and return trimmed stdout/stderr output.
- Introduce a specialized Segment Documentation GitHub agent and extend the segment generation prompt with documentation delegation guidance.

Build:
- Switch markdown lint configuration to markdownlint-cli2, add path ignores, and remove the legacy .markdownlintignore file.

Documentation:
- Document additional git segment template properties and introduce internal guidance for automated segment documentation generation.

Tests:
- Extend winget segment tests to cover outputs with trailing messages and unexpected characters before the header.
- Add a unit test to verify goroutine ID retrieval via the jobs runtime helper.